### PR TITLE
ci: add golangci-lint config, helm-unittest, race detector and coverage gate

### DIFF
--- a/.github/workflows/_go.yaml
+++ b/.github/workflows/_go.yaml
@@ -4,19 +4,6 @@ on:
   workflow_call:
 
 jobs:
-  encoding:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Reject Unicode smart quotes
-        run: |
-          if LC_ALL=C grep -rn $'\xe2\x80\x9c\|\xe2\x80\x9d\|\xe2\x80\x98\|\xe2\x80\x99' --include='*.go' --include='*.yaml' --include='*.yml' --include='*.tpl' .; then
-            echo "::error::Found Unicode smart quotes (U+201C/U+201D/U+2018/U+2019). Replace with ASCII quotes."
-            exit 1
-          fi
-
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -36,7 +23,8 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          # renovate: datasource=github-releases depName=golangci/golangci-lint
+          version: "v2.13.2"
 
   vulncheck:
     runs-on: ubuntu-latest
@@ -91,7 +79,10 @@ jobs:
           go-version-file: go.mod
 
       - name: Run tests
-        run: go test ./... -coverprofile cover.out
+        run: go test ./... -race -covermode=atomic -coverprofile cover.out
+
+      - name: Check coverage threshold
+        run: ./hack/check-coverage.sh cover.out 55
 
       - name: Upload coverage
         uses: actions/upload-artifact@v7

--- a/.github/workflows/_helm.yaml
+++ b/.github/workflows/_helm.yaml
@@ -13,8 +13,14 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v5
 
+      - name: Install helm-unittest plugin
+        run: helm plugin install --verify=false https://github.com/helm-unittest/helm-unittest
+
       - name: Helm lint
         run: helm lint charts/crashloop-operator
 
       - name: Helm template
         run: helm template test charts/crashloop-operator
+
+      - name: Helm unittest
+        run: helm unittest charts/crashloop-operator

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,31 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  default: standard
+  enable:
+    - errorlint
+    - gosec
+    - misspell
+    - revive
+    - unconvert
+  settings:
+    revive:
+      rules:
+        - name: exported
+          disabled: true
+  exclusions:
+    generated: lax
+    rules:
+      # Test helpers construct fixtures with hardcoded values and do not need
+      # the same hardening as production code.
+      - path: _test\.go
+        linters:
+          - gosec
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ NAMESPACE ?= crashloop-system
 CONTAINER_TOOL ?= $(shell which podman 2>/dev/null || which docker 2>/dev/null)
 CONTROLLER_GEN = go tool controller-gen
 GOVULNCHECK = go tool govulncheck
+COVERAGE_THRESHOLD ?= 55
 
 .PHONY: all
 all: build
@@ -28,7 +29,11 @@ vet: ## Run go vet.
 
 .PHONY: test
 test: manifests generate fmt vet ## Run tests.
-	go test ./... -coverprofile cover.out
+	go test ./... -race -covermode=atomic -coverprofile cover.out
+
+.PHONY: check-coverage
+check-coverage: test ## Run tests and enforce the coverage threshold.
+	./hack/check-coverage.sh cover.out $(COVERAGE_THRESHOLD)
 
 ##@ Build
 
@@ -80,22 +85,29 @@ GOLANGCI_LINT ?= $(shell which golangci-lint 2>/dev/null)
 
 .PHONY: lint
 lint: ## Run golangci-lint.
+	@if [ -z "$(GOLANGCI_LINT)" ]; then \
+		echo "error: golangci-lint not found on PATH."; \
+		echo "Install it from https://golangci-lint.run/welcome/install/ (CI pins the version in .github/workflows/_go.yaml)."; \
+		exit 1; \
+	fi
 	$(GOLANGCI_LINT) run ./...
 
 .PHONY: vulncheck
 vulncheck: ## Run govulncheck.
 	$(GOVULNCHECK) ./...
 
+GENERATED_PATHS = api/v1alpha1/zz_generated.deepcopy.go config/crd/bases charts/crashloop-operator/crds
+
 .PHONY: check-manifests
 check-manifests: manifests generate ## Check for CRD and deepcopy drift.
-	@if ! git diff --quiet; then \
+	@if ! git diff --quiet -- $(GENERATED_PATHS); then \
 		echo "error: generated files are out of date. Run 'make manifests generate' and commit the result."; \
-		git diff --stat; \
+		git diff --stat -- $(GENERATED_PATHS); \
 		exit 1; \
 	fi
 
 .PHONY: ci
-ci: lint vet test check-manifests vulncheck helm-lint helm-unittest ## Run all CI checks locally.
+ci: lint vet check-coverage check-manifests vulncheck helm-lint helm-unittest ## Run all CI checks locally.
 	@echo "All CI checks passed."
 
 ##@ Help

--- a/hack/check-coverage.sh
+++ b/hack/check-coverage.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROFILE="${1:?usage: check-coverage.sh <cover.out> <threshold>}"
+THRESHOLD="${2:?usage: check-coverage.sh <cover.out> <threshold>}"
+
+TOTAL=$(go tool cover -func="$PROFILE" | tail -1 | awk '{print $NF}' | tr -d '%')
+
+echo "Total coverage: ${TOTAL}%  (threshold: ${THRESHOLD}%)"
+
+if awk "BEGIN {exit !(${TOTAL} < ${THRESHOLD})}"; then
+  echo "FAIL: coverage ${TOTAL}% is below threshold ${THRESHOLD}%"
+  exit 1
+fi
+
+echo "OK: coverage meets threshold"


### PR DESCRIPTION
## Summary

- Adds `.golangci.yml` (v2 format) enabling errorlint, gosec, misspell, revive and unconvert on top of the standard linter set, and pins golangci-lint to v2.13.2 with a renovate annotation. CI previously ran `version: latest` with no config, so only the default linters applied and the ruleset could change without a commit.
- Wires the 28 existing helm-unittest cases into the Helm workflow. They were runnable via `make helm-unittest` but never executed in CI.
- Runs tests with `-race -covermode=atomic` and enforces a coverage threshold of 55 percent via `hack/check-coverage.sh`, ported from openvox-operator. Current coverage is 56.1 percent.
- Removes the `encoding` job from `_go.yaml`: its smart-quote grep is a strict subset of the unicode-lint workflow that runs alongside it.
- `make lint` now fails with an install hint instead of silently expanding to an empty command when golangci-lint is not on PATH.
- `check-manifests` now diffs only the generated paths. It previously diffed the whole worktree, so any unrelated local edit made `make ci` fail with a misleading drift error.

Closes #21

## Test plan

- `make ci` passes locally end to end: golangci-lint reports 0 issues with the new linters confirmed active via `golangci-lint linters`, tests pass under the race detector, the coverage gate reports 56.1 percent against the 55 percent threshold, and all 28 helm-unittest cases pass.
- `golangci-lint config verify` accepts the new config file.