### PR TITLE
chore: align renovate config with openvox-operator

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,22 @@
   "labels": [
     "dependencies"
   ],
+  "postUpdateOptions": [
+    "gomodTidy"
+  ],
+  "platformAutomerge": false,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/).github/workflows/_go\\.yaml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+version: \"(?<currentValue>[^\"]+)\""
+      ],
+      "extractVersionTemplate": "^v?(?<version>.*)$"
+    }
+  ],
   "packageRules": [
     {
       "matchDepNames": [
@@ -20,20 +36,7 @@
         "gomod"
       ],
       "groupName": "Go dependencies",
-      "postUpgradeTasks": {
-        "commands": [
-          "go mod tidy",
-          "make generate manifests"
-        ],
-        "fileFilters": [
-          "go.mod",
-          "go.sum",
-          "api/**",
-          "config/crd/**",
-          "charts/crashloop-operator/crds/**"
-        ],
-        "executionMode": "branch"
-      }
+      "semanticCommitType": "fix"
     },
     {
       "matchManagers": [
@@ -45,7 +48,69 @@
       "matchManagers": [
         "dockerfile"
       ],
-      "groupName": "Container base images"
+      "groupName": "Container base images",
+      "semanticCommitType": "fix"
+    },
+    {
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDatasources": [
+        "github-releases"
+      ],
+      "groupName": "CI tooling"
+    },
+    {
+      "description": "Automerge CI tooling (golangci-lint, ...) minor/patch once CI is green",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDatasources": [
+        "github-releases"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "automerge": true
+    },
+    {
+      "description": "Automerge container base image updates (excludes the Go toolchain image)",
+      "matchManagers": [
+        "dockerfile"
+      ],
+      "matchPackageNames": [
+        "!docker.io/library/golang"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest",
+        "pin"
+      ],
+      "automerge": true
+    },
+    {
+      "description": "Automerge GitHub Actions minor/patch (majors stay manual)",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "automerge": true
+    },
+    {
+      "description": "Automerge Go module patch/digest updates (minor/major stay manual)",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "digest"
+      ],
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Drops `postUpgradeTasks` (`go mod tidy`, `make generate manifests`). It only runs on self-hosted Renovate with an explicit allowlist, so on the hosted Mend app it silently did nothing and Go dependency PRs stayed red on the manifests drift gate. `postUpdateOptions: [gomodTidy]` covers what actually worked.
- Adds a custom regex manager for the golangci-lint version pinned in `_go.yaml` (added in #21), so the pin stays current instead of going stale.
- Adds `semanticCommitType: fix` to the gomod and dockerfile groups so dependency updates produce patch releases rather than being release-neutral chores.
- Adds automerge for low-risk updates: CI tooling minor/patch, container base images except the Go toolchain image, GitHub Actions minor/patch, and Go module patch/digest. Majors and Go module minors stay manual, as in openvox-operator.

Closes #24

## Test plan

- `renovate-config-validator` passes against Renovate 44.65.5. Note that a stale npx cache may resolve Renovate 37, which predates `managerFilePatterns` and reports a false error; pin `renovate@latest` when validating locally.
- Verified the custom manager regex matches the golangci-lint pin in `_go.yaml`, extracting datasource, depName and `v2.13.2`.
- Effect on automerge is observable on the next Renovate run; nothing in this change affects the build.