### PR TITLE
chore: tidy gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,20 @@
-*.tar.gz
-*.jar
 *.swp
+.DS_Store
 .env
+
+# Build output
 bin/
+dist/
+*.tar.gz
+*.tgz
+
+# Test and coverage artifacts
 cover.out
+coverage.html
+*.test
+__debug_bin*
+
 node_modules/
+
+# Local agent settings, not shared with the repository
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

Adds `*.tgz` (Helm packages, which `*.tar.gz` does not match), `coverage.html`, `*.test`, `__debug_bin*`, `dist/` and `.DS_Store`, plus `.claude/settings.local.json` so it stays untracked without relying on each contributor having it in their global ignore file. Drops the vestigial `*.jar` entry and groups the rest by purpose.

Three of the five items in the issue turned out not to need a change, so I left them alone rather than churn the repo:

- **LICENSE placeholders are not a defect.** `Copyright [yyyy] [name of copyright owner]` sits inside the "APPENDIX: How to apply the Apache License to your work" section, which is canonical Apache-2.0 boilerplate explaining how a user applies the license to their own work. It is not a statement about this project, and editing it would deviate from the standard license text. openvox-operator, the quality reference for this repo, leaves it identical. If per-file attribution is ever wanted, a NOTICE file or SPDX headers are the right mechanism.
- **`.claude/settings.local.json` was never committed.** `git ls-files .claude/` lists only `commands/autodev.md`. It was untracked because of a global ignore rule on this machine, which is why the repo-level entry above is still worth adding.
- **The empty directories are not in git.** `charts/crashloop-operator/templates/tests` and `tests/__snapshot__` contain no tracked files, so they never reach a fresh clone. I removed them from my working copy; there is nothing to commit.

The remaining item, `paths-ignore: docs/**` pointing at a directory that does not exist yet, is harmless and resolves when #28 adds the docs tree.

Closes #33

## Test plan

- `make ci` passes locally end to end.
- Verified a `.tgz` file in the repo root is now ignored.