### PR TITLE
fix(api)!: make CrashLoopPolicy cluster-scoped

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ The controller reconciles on a configurable interval (default: 60s) and on pod e
 
 The operator introduces a single CRD: **`CrashLoopPolicy`** (`crashloop-operator.lauger.de/v1alpha1`).
 
+`CrashLoopPolicy` is **cluster-scoped**. A policy evaluates workloads across the
+whole cluster, so it is an administrative resource: grant write access to it the
+same way you would grant any other cluster-wide permission. Use
+`namespaceSelector` and `excludeNamespaces` to limit which namespaces a policy
+acts on, and the chart's `scope.mode` to confine the operator itself to a single
+namespace.
+
 | Field | Default | Description |
 |---|---|---|
 | `watchReasons` | `[CrashLoopBackOff, ImagePullBackOff, ErrImagePull, CreateContainerConfigError, InvalidImageName, RunContainerError]` | Container waiting reasons to watch |
@@ -81,7 +88,6 @@ apiVersion: crashloop-operator.lauger.de/v1alpha1
 kind: CrashLoopPolicy
 metadata:
   name: default
-  namespace: default
 spec:
   restartThreshold: 10
   durationThreshold: "30m"

--- a/api/v1alpha1/crashlooppolicy_types.go
+++ b/api/v1alpha1/crashlooppolicy_types.go
@@ -81,6 +81,7 @@ type CrashLoopPolicyStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Scaled Down",type=integer,JSONPath=`.status.scaledDownWorkloads`

--- a/charts/crashloop-operator/crds/crashloop-operator.lauger.de_crashlooppolicies.yaml
+++ b/charts/crashloop-operator/crds/crashloop-operator.lauger.de_crashlooppolicies.yaml
@@ -12,7 +12,7 @@ spec:
     listKind: CrashLoopPolicyList
     plural: crashlooppolicies
     singular: crashlooppolicy
-  scope: Namespaced
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.phase

--- a/charts/crashloop-operator/templates/clusterrole.yaml
+++ b/charts/crashloop-operator/templates/clusterrole.yaml
@@ -1,14 +1,11 @@
+{{/*
+CrashLoopPolicy and namespaces are cluster-scoped resources, so access to
+them always requires a ClusterRole regardless of scope.mode.
+*/}}
 apiVersion: rbac.authorization.k8s.io/v1
-{{- if eq .Values.scope.mode "namespace" }}
-kind: Role
-{{- else }}
 kind: ClusterRole
-{{- end }}
 metadata:
   name: {{ include "crashloop-operator.fullname" . }}
-  {{- if eq .Values.scope.mode "namespace" }}
-  namespace: {{ .Values.scope.watchNamespace | default .Release.Namespace }}
-  {{- end }}
   labels:
     {{- include "crashloop-operator.labels" . | nindent 4 }}
 rules:
@@ -24,6 +21,33 @@ rules:
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "list", "watch"]
+  {{/*
+  Events are recorded against the CrashLoopPolicy, which is cluster-scoped,
+  so the API server files them under the default namespace rather than the
+  watched one. A namespaced Role would therefore never grant this.
+  */}}
+  - apiGroups: ["", "events.k8s.io"]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+{{/*
+Workload access follows scope.mode: cluster-wide by default, or confined to
+a single namespace when scope.mode is "namespace".
+*/}}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- if eq .Values.scope.mode "namespace" }}
+kind: Role
+{{- else }}
+kind: ClusterRole
+{{- end }}
+metadata:
+  name: {{ include "crashloop-operator.fullname" . }}-workloads
+  {{- if eq .Values.scope.mode "namespace" }}
+  namespace: {{ .Values.scope.watchNamespace | default .Release.Namespace }}
+  {{- end }}
+  labels:
+    {{- include "crashloop-operator.labels" . | nindent 4 }}
+rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "watch"]
@@ -42,9 +66,6 @@ rules:
   - apiGroups: ["batch"]
     resources: ["cronjobs"]
     verbs: ["get", "list", "watch", "update", "patch"]
-  - apiGroups: ["", "events.k8s.io"]
-    resources: ["events"]
-    verbs: ["create", "patch"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/charts/crashloop-operator/templates/clusterrolebinding.yaml
+++ b/charts/crashloop-operator/templates/clusterrolebinding.yaml
@@ -1,11 +1,26 @@
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "crashloop-operator.fullname" . }}
+  labels:
+    {{- include "crashloop-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "crashloop-operator.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "crashloop-operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
 {{- if eq .Values.scope.mode "namespace" }}
 kind: RoleBinding
 {{- else }}
 kind: ClusterRoleBinding
 {{- end }}
 metadata:
-  name: {{ include "crashloop-operator.fullname" . }}
+  name: {{ include "crashloop-operator.fullname" . }}-workloads
   {{- if eq .Values.scope.mode "namespace" }}
   namespace: {{ .Values.scope.watchNamespace | default .Release.Namespace }}
   {{- end }}
@@ -18,7 +33,7 @@ roleRef:
   {{- else }}
   kind: ClusterRole
   {{- end }}
-  name: {{ include "crashloop-operator.fullname" . }}
+  name: {{ include "crashloop-operator.fullname" . }}-workloads
 subjects:
   - kind: ServiceAccount
     name: {{ include "crashloop-operator.serviceAccountName" . }}

--- a/charts/crashloop-operator/tests/rbac_test.yaml
+++ b/charts/crashloop-operator/tests/rbac_test.yaml
@@ -3,24 +3,68 @@ templates:
   - templates/clusterrole.yaml
   - templates/clusterrolebinding.yaml
 tests:
-  - it: should create ClusterRole in cluster mode
+  # Document 0 covers the cluster-scoped CrashLoopPolicy and namespaces.
+  # Document 1 covers workloads and follows scope.mode.
+  - it: should grant policy access via ClusterRole in cluster mode
     template: templates/clusterrole.yaml
+    documentIndex: 0
     asserts:
       - isKind:
           of: ClusterRole
       - isNull:
           path: metadata.namespace
 
-  - it: should create ClusterRoleBinding in cluster mode
+  - it: should grant policy access via ClusterRole even in namespace mode
+    template: templates/clusterrole.yaml
+    documentIndex: 0
+    set:
+      scope:
+        mode: namespace
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - isNull:
+          path: metadata.namespace
+
+  - it: should bind policy ClusterRole cluster-wide in namespace mode
     template: templates/clusterrolebinding.yaml
+    documentIndex: 0
+    set:
+      scope:
+        mode: namespace
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - isNull:
+          path: metadata.namespace
+      - equal:
+          path: roleRef.kind
+          value: ClusterRole
+
+  - it: should create workload ClusterRole in cluster mode
+    template: templates/clusterrole.yaml
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - isNull:
+          path: metadata.namespace
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-crashloop-operator-workloads
+
+  - it: should create workload ClusterRoleBinding in cluster mode
+    template: templates/clusterrolebinding.yaml
+    documentIndex: 1
     asserts:
       - isKind:
           of: ClusterRoleBinding
       - isNull:
           path: metadata.namespace
 
-  - it: should create Role in namespace mode
+  - it: should create workload Role in namespace mode
     template: templates/clusterrole.yaml
+    documentIndex: 1
     set:
       scope:
         mode: namespace
@@ -30,8 +74,9 @@ tests:
       - isNotNull:
           path: metadata.namespace
 
-  - it: should create RoleBinding in namespace mode
+  - it: should create workload RoleBinding in namespace mode
     template: templates/clusterrolebinding.yaml
+    documentIndex: 1
     set:
       scope:
         mode: namespace
@@ -40,9 +85,13 @@ tests:
           of: RoleBinding
       - isNotNull:
           path: metadata.namespace
+      - equal:
+          path: roleRef.kind
+          value: Role
 
-  - it: should use custom watchNamespace for Role
+  - it: should use custom watchNamespace for the workload Role
     template: templates/clusterrole.yaml
+    documentIndex: 1
     set:
       scope:
         mode: namespace
@@ -54,6 +103,7 @@ tests:
 
   - it: should grant CRD permissions
     template: templates/clusterrole.yaml
+    documentIndex: 0
     asserts:
       - contains:
           path: rules
@@ -62,8 +112,23 @@ tests:
             resources: ["crashlooppolicies"]
             verbs: ["get", "list", "watch", "update", "patch"]
 
+  - it: should grant event permissions cluster-wide
+    template: templates/clusterrole.yaml
+    documentIndex: 0
+    set:
+      scope:
+        mode: namespace
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["", "events.k8s.io"]
+            resources: ["events"]
+            verbs: ["create", "patch"]
+
   - it: should grant pod read permissions
     template: templates/clusterrole.yaml
+    documentIndex: 1
     asserts:
       - contains:
           path: rules
@@ -74,6 +139,7 @@ tests:
 
   - it: should grant deployment write permissions
     template: templates/clusterrole.yaml
+    documentIndex: 1
     asserts:
       - contains:
           path: rules
@@ -84,6 +150,7 @@ tests:
 
   - it: should grant lease permissions for leader election
     template: templates/clusterrole.yaml
+    documentIndex: 1
     asserts:
       - contains:
           path: rules
@@ -94,6 +161,7 @@ tests:
 
   - it: should reference correct ServiceAccount
     template: templates/clusterrolebinding.yaml
+    documentIndex: 0
     release:
       namespace: my-ns
     asserts:

--- a/config/crd/bases/crashloop-operator.lauger.de_crashlooppolicies.yaml
+++ b/config/crd/bases/crashloop-operator.lauger.de_crashlooppolicies.yaml
@@ -12,7 +12,7 @@ spec:
     listKind: CrashLoopPolicyList
     plural: crashlooppolicies
     singular: crashlooppolicy
-  scope: Namespaced
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.phase

--- a/config/samples/crashlooppolicy_v1alpha1.yaml
+++ b/config/samples/crashlooppolicy_v1alpha1.yaml
@@ -2,7 +2,6 @@ apiVersion: crashloop-operator.lauger.de/v1alpha1
 kind: CrashLoopPolicy
 metadata:
   name: default
-  namespace: default
 spec:
   watchReasons:
     - CrashLoopBackOff

--- a/internal/controller/crashlooppolicy_controller.go
+++ b/internal/controller/crashlooppolicy_controller.go
@@ -168,7 +168,7 @@ func (r *CrashLoopPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 
 		// Scale down or suspend the workload
-		scaleReason := fmt.Sprintf("pods failing with %s (policy: %s/%s)", reason, policy.Namespace, policy.Name)
+		scaleReason := fmt.Sprintf("pods failing with %s (policy: %s)", reason, policy.Name)
 		acted, err := scaleDownWorkload(ctx, r.Client, owner, scaleReason, policy.Spec.DryRun)
 		if err != nil {
 			logger.Error(err, "failed to scale down workload", "workload", key)

--- a/internal/controller/testutil_test.go
+++ b/internal/controller/testutil_test.go
@@ -42,9 +42,11 @@ func testRecorder() events.EventRecorder {
 	return events.NewFakeRecorder(100)
 }
 
+// testRequest builds a request for a CrashLoopPolicy. The CRD is
+// cluster-scoped, so the key carries no namespace.
 func testRequest(name string) ctrl.Request {
 	return ctrl.Request{
-		NamespacedName: client.ObjectKey{Name: name, Namespace: testNamespace},
+		NamespacedName: client.ObjectKey{Name: name},
 	}
 }
 
@@ -59,8 +61,7 @@ type policyOption func(*crashloopv1alpha1.CrashLoopPolicy)
 func newCrashLoopPolicy(name string, opts ...policyOption) *crashloopv1alpha1.CrashLoopPolicy {
 	p := &crashloopv1alpha1.CrashLoopPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: testNamespace,
+			Name: name,
 		},
 		Spec: crashloopv1alpha1.CrashLoopPolicySpec{
 			WatchReasons:       []string{"CrashLoopBackOff", "ImagePullBackOff", "ErrImagePull", "CreateContainerConfigError", "InvalidImageName", "RunContainerError"},


### PR DESCRIPTION
## Summary

The CRD was namespace-scoped while the reconciler listed pods across all namespaces and scaled down workloads anywhere in the cluster. Anyone permitted to create a CrashLoopPolicy in their own namespace therefore had cluster-wide blast radius, which is a privilege escalation footgun.

I took option 1 from the issue (make the CRD cluster-scoped) rather than confining evaluation to the policy's own namespace, because the spec already carries `namespaceSelector` and `excludeNamespaces`. Those two fields only mean anything for a cluster-wide policy, so the scope marker is what was wrong, not the behaviour. Option 2 would have made both fields meaningless.

Chart RBAC is split to match:

- **Always a ClusterRole** for `crashlooppolicies` (+status, +finalizers), `namespaces` and events. The first two are cluster-scoped resources that a Role cannot grant at all. Events are the subtle one: they are recorded against the CrashLoopPolicy, and the API server files events for a cluster-scoped object under the `default` namespace, so a Role in the watched namespace would never cover them.
- **Workload access still follows `scope.mode`**: a Role in the watched namespace, or a ClusterRole cluster-wide.

Worth noting: the previous namespace mode was already partly broken, because its Role granted `namespaces` (a cluster-scoped resource) and so could never satisfy `resolveNamespaces`.

The controller needed almost no change. `client.ObjectKeyFromObject` already produces a namespace-less key for cluster-scoped objects, so the only fix was the scale-down reason string, which rendered as `/name` once the namespace was empty.

BREAKING CHANGE: existing namespaced policies must be recreated without `metadata.namespace`. Pre-1.0 this releases as a minor version per `.releaserc.json`.

Closes #18

## Test plan

- `make ci` passes locally end to end. Chart tests grew from 28 to 32 cases; the RBAC suite was rewritten for the two rendered documents and now asserts the key new invariant, that policy access stays a ClusterRole even when `scope.mode` is `namespace`.
- Verified the generated CRD carries `scope: Cluster`.
- Rendered the chart in both modes: cluster mode yields two ClusterRoles plus two ClusterRoleBindings; namespace mode yields the policy ClusterRole and ClusterRoleBinding plus a Role and RoleBinding confined to the watched namespace.