### PR TITLE
feat(controller): resolve overlapping policies by restrictiveness

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,32 @@ When a workload is scaled down, the operator adds these annotations:
 | `crashloop-operator.lauger.de/scaled-down-reason` | Human-readable reason for the scale-down |
 | `crashloop-operator.lauger.de/scaled-down-at` | RFC3339 timestamp of when the scale-down occurred |
 | `crashloop-operator.lauger.de/previous-replicas` | Previous replica count (Deployments and StatefulSets only) |
+| `crashloop-operator.lauger.de/scaled-down-by` | Name of the policy that performed the scale-down |
+
+## Multiple Policies
+
+Policies are cluster-scoped and every policy sees every workload, so more than
+one can match the same workload. When that happens **the most restrictive policy
+wins**: it performs the scale-down, records itself in the
+`scaled-down-by` annotation, and counts the action in its own status. Every
+other matching policy leaves the workload alone, so a workload is never scaled
+down twice or attributed to two policies.
+
+Only policies that would actually act on the workload right now take part in
+that comparison. A policy whose `watchReasons` do not cover the observed failure,
+or whose thresholds are not yet exceeded, cannot win and therefore cannot block a
+policy that would act.
+
+Restrictiveness is compared in this order, and the first difference decides:
+
+1. Lower `restartThreshold`
+2. Shorter `durationThreshold`
+3. `allReplicasFailing: false` before `true`, since it also acts on partial failure
+4. `dryRun: false` before `true`, so a real action outranks a simulated one
+5. Name in ascending order, purely to break a remaining tie
+
+Because the order is total, the winner does not depend on the order in which
+policies are evaluated.
 
 ## Local Development
 

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -8,11 +8,25 @@ const (
 	RequeueIntervalShort   = 10 * time.Second
 )
 
-// Default thresholds.
+// Default thresholds. These mirror the kubebuilder defaults on the CRD fields
+// and must be kept in sync with them.
 const (
 	DefaultRestartThreshold  = int32(10)
 	DefaultDurationThreshold = "30m"
 )
+
+// DefaultWatchReasons mirrors the kubebuilder default on spec.watchReasons.
+var DefaultWatchReasons = []string{
+	"CrashLoopBackOff",
+	"ImagePullBackOff",
+	"ErrImagePull",
+	"CreateContainerConfigError",
+	"InvalidImageName",
+	"RunContainerError",
+}
+
+// DefaultTargets mirrors the kubebuilder default on spec.targets.
+var DefaultTargets = []string{"Deployment", "StatefulSet", "CronJob"}
 
 // MaxActiveScaledDown caps status.activeScaledDown. A cluster-wide policy could
 // otherwise grow the object past the etcd size limit. It must stay in sync with
@@ -24,6 +38,9 @@ const (
 	AnnotationScaledDownReason = "crashloop-operator.lauger.de/scaled-down-reason"
 	AnnotationScaledDownAt     = "crashloop-operator.lauger.de/scaled-down-at"
 	AnnotationPreviousReplicas = "crashloop-operator.lauger.de/previous-replicas"
+	// AnnotationScaledDownBy names the policy that performed the scale-down, so
+	// that overlapping policies can attribute actions correctly.
+	AnnotationScaledDownBy = "crashloop-operator.lauger.de/scaled-down-by"
 )
 
 // Event reasons.

--- a/internal/controller/crashlooppolicy_controller.go
+++ b/internal/controller/crashlooppolicy_controller.go
@@ -55,36 +55,25 @@ func (r *CrashLoopPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 	}
 
-	// Parse duration threshold
-	durationThreshold := parseDuration(policy.Spec.DurationThreshold)
+	durationThreshold := effectiveDurationThreshold(policy)
+	watchReasons := effectiveWatchReasons(policy)
+	restartThreshold := effectiveRestartThreshold(policy)
+	targets := effectiveTargets(policy)
+	requireAllReplicasFailing := effectiveAllReplicasFailing(policy)
+	dryRun := effectiveDryRun(policy)
 
-	// Use defaults if not set
-	watchReasons := policy.Spec.WatchReasons
-	if len(watchReasons) == 0 {
-		watchReasons = []string{"CrashLoopBackOff", "ImagePullBackOff", "ErrImagePull", "CreateContainerConfigError", "InvalidImageName", "RunContainerError"}
+	// Every policy sees every pod, so overlapping policies have to agree on who
+	// acts. Load the full set once and let the most restrictive matching policy
+	// win each workload.
+	policyList := &crashloopv1alpha1.CrashLoopPolicyList{}
+	if err := r.List(ctx, policyList); err != nil {
+		logger.Error(err, "failed to list policies")
+		return ctrl.Result{}, err
 	}
-
-	restartThreshold := policy.Spec.RestartThreshold
-	if restartThreshold == 0 {
-		restartThreshold = DefaultRestartThreshold
-	}
-
-	targets := policy.Spec.Targets
-	if len(targets) == 0 {
-		targets = []string{"Deployment", "StatefulSet", "CronJob"}
-	}
-
-	// The API server applies the kubebuilder defaults, but the fields are
-	// pointers so that an explicit false is not lost. Fall back here for
-	// objects that never went through defaulting.
-	requireAllReplicasFailing := true
-	if policy.Spec.AllReplicasFailing != nil {
-		requireAllReplicasFailing = *policy.Spec.AllReplicasFailing
-	}
-	dryRun := policy.Spec.DryRun != nil && *policy.Spec.DryRun
+	nsResolver := newNamespaceResolver(r.Client)
 
 	// Resolve allowed namespaces from namespaceSelector
-	allowedNamespaces, err := resolveNamespaces(ctx, r.Client, policy.Spec.NamespaceSelector)
+	allowedNamespaces, err := nsResolver.allowed(ctx, policy)
 	if err != nil {
 		logger.Error(err, "failed to resolve namespace selector")
 		return ctrl.Result{}, err
@@ -177,9 +166,23 @@ func (r *CrashLoopPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			}
 		}
 
+		// Several policies may match this workload. The most restrictive one
+		// owns the action; the others leave it alone so that the workload is
+		// scaled down once and by an identifiable policy.
+		winner, err := winningPolicy(ctx, r.Client, nsResolver, policyList.Items, pod, owner)
+		if err != nil {
+			logger.Error(err, "failed to resolve winning policy", "workload", key)
+			continue
+		}
+		if winner != nil && winner.Name != policy.Name {
+			logger.V(1).Info("another policy is more restrictive for this workload, skipping",
+				"workload", key, "winner", winner.Name)
+			continue
+		}
+
 		// Scale down or suspend the workload
 		scaleReason := fmt.Sprintf("pods failing with %s (policy: %s)", reason, policy.Name)
-		acted, err := scaleDownWorkload(ctx, r.Client, owner, scaleReason, dryRun)
+		acted, err := scaleDownWorkload(ctx, r.Client, owner, scaleReason, policy.Name, dryRun)
 		if err != nil {
 			logger.Error(err, "failed to scale down workload", "workload", key)
 			continue
@@ -203,7 +206,7 @@ func (r *CrashLoopPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	// Collect currently active scaled-down workloads
-	activeScaledDown, err := findActiveScaledDownWorkloads(ctx, r.Client, allowedNamespaces, policy.Spec.ExcludeNamespaces, targets)
+	activeScaledDown, err := findActiveScaledDownWorkloads(ctx, r.Client, allowedNamespaces, policy.Spec.ExcludeNamespaces, targets, policy.Name)
 	if err != nil {
 		logger.Error(err, "failed to find active scaled-down workloads")
 	}

--- a/internal/controller/crashlooppolicy_controller_test.go
+++ b/internal/controller/crashlooppolicy_controller_test.go
@@ -774,3 +774,137 @@ func TestReconcile_SetsObservedGeneration(t *testing.T) {
 		t.Errorf("expected observedGeneration 7, got %d", updated.Status.ObservedGeneration)
 	}
 }
+
+func TestReconcile_MostRestrictivePolicyWins(t *testing.T) {
+	// Two policies match the same workload. The one with the lower restart
+	// threshold is more restrictive and must own the action; the other must
+	// leave the workload alone so it is not attributed twice.
+	strict := newCrashLoopPolicy("strict", withAllReplicasFailing(false), withRestartThreshold(5))
+	lax := newCrashLoopPolicy("lax", withAllReplicasFailing(false), withRestartThreshold(10))
+	deploy := newDeployment("my-app", testNamespace, 3)
+	rs := newReplicaSet("my-app-rs", testNamespace, "my-app", "deploy-uid-1")
+	pod := newFailingPod("my-app-pod-1", testNamespace, rsOwnerRef(), "CrashLoopBackOff", 15)
+
+	c := setupTestClient(strict, lax, deploy, rs, pod)
+	r := newReconciler(c)
+
+	// Reconcile the less restrictive policy first: it must defer.
+	if _, err := r.Reconcile(testCtx(), testRequest("lax")); err != nil {
+		t.Fatalf("unexpected error reconciling lax: %v", err)
+	}
+	updated := &appsv1.Deployment{}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "my-app", Namespace: testNamespace}, updated); err != nil {
+		t.Fatalf("failed to get deployment: %v", err)
+	}
+	if updated.Spec.Replicas != nil && *updated.Spec.Replicas == 0 {
+		t.Fatal("expected the less restrictive policy to defer to the more restrictive one")
+	}
+
+	// The more restrictive policy acts and records itself.
+	if _, err := r.Reconcile(testCtx(), testRequest("strict")); err != nil {
+		t.Fatalf("unexpected error reconciling strict: %v", err)
+	}
+	if err := c.Get(testCtx(), types.NamespacedName{Name: "my-app", Namespace: testNamespace}, updated); err != nil {
+		t.Fatalf("failed to get deployment: %v", err)
+	}
+	if updated.Spec.Replicas == nil || *updated.Spec.Replicas != 0 {
+		t.Error("expected the most restrictive policy to scale the deployment down")
+	}
+	if got := updated.Annotations[AnnotationScaledDownBy]; got != "strict" {
+		t.Errorf("expected scaled-down-by=strict, got %q", got)
+	}
+}
+
+func TestReconcile_ActiveScaledDownAttributedToOwningPolicy(t *testing.T) {
+	strict := newCrashLoopPolicy("strict", withAllReplicasFailing(false), withRestartThreshold(5))
+	lax := newCrashLoopPolicy("lax", withAllReplicasFailing(false), withRestartThreshold(10))
+	deploy := newDeployment("my-app", testNamespace, 3)
+	rs := newReplicaSet("my-app-rs", testNamespace, "my-app", "deploy-uid-1")
+	pod := newFailingPod("my-app-pod-1", testNamespace, rsOwnerRef(), "CrashLoopBackOff", 15)
+
+	c := setupTestClient(strict, lax, deploy, rs, pod)
+	r := newReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("strict")); err != nil {
+		t.Fatalf("unexpected error reconciling strict: %v", err)
+	}
+	if _, err := r.Reconcile(testCtx(), testRequest("lax")); err != nil {
+		t.Fatalf("unexpected error reconciling lax: %v", err)
+	}
+
+	owning := &crashloopv1alpha1.CrashLoopPolicy{}
+	if err := c.Get(testCtx(), client.ObjectKey{Name: "strict"}, owning); err != nil {
+		t.Fatalf("failed to get strict policy: %v", err)
+	}
+	if len(owning.Status.ActiveScaledDown) != 1 {
+		t.Errorf("expected the owning policy to list 1 workload, got %d", len(owning.Status.ActiveScaledDown))
+	}
+	if owning.Status.ScaledDownWorkloads != 1 {
+		t.Errorf("expected the owning policy counter to be 1, got %d", owning.Status.ScaledDownWorkloads)
+	}
+
+	other := &crashloopv1alpha1.CrashLoopPolicy{}
+	if err := c.Get(testCtx(), client.ObjectKey{Name: "lax"}, other); err != nil {
+		t.Fatalf("failed to get lax policy: %v", err)
+	}
+	if len(other.Status.ActiveScaledDown) != 0 {
+		t.Errorf("expected the non-owning policy to list no workloads, got %d", len(other.Status.ActiveScaledDown))
+	}
+	if other.Status.ScaledDownWorkloads != 0 {
+		t.Errorf("expected the non-owning policy counter to stay 0, got %d", other.Status.ScaledDownWorkloads)
+	}
+}
+
+func TestIsMoreRestrictive(t *testing.T) {
+	tests := []struct {
+		name string
+		a    *crashloopv1alpha1.CrashLoopPolicy
+		b    *crashloopv1alpha1.CrashLoopPolicy
+		want bool
+	}{
+		{
+			name: "lower restart threshold wins",
+			a:    newCrashLoopPolicy("a", withRestartThreshold(3)),
+			b:    newCrashLoopPolicy("b", withRestartThreshold(9)),
+			want: true,
+		},
+		{
+			name: "shorter duration wins when restarts tie",
+			a:    newCrashLoopPolicy("a", withDurationThreshold("5m")),
+			b:    newCrashLoopPolicy("b", withDurationThreshold("1h")),
+			want: true,
+		},
+		{
+			name: "allReplicasFailing false wins",
+			a:    newCrashLoopPolicy("a", withAllReplicasFailing(false)),
+			b:    newCrashLoopPolicy("b", withAllReplicasFailing(true)),
+			want: true,
+		},
+		{
+			name: "real action outranks dry run",
+			a:    newCrashLoopPolicy("a", withDryRun(false)),
+			b:    newCrashLoopPolicy("b", withDryRun(true)),
+			want: true,
+		},
+		{
+			name: "name breaks a full tie",
+			a:    newCrashLoopPolicy("aaa"),
+			b:    newCrashLoopPolicy("bbb"),
+			want: true,
+		},
+		{
+			name: "not more restrictive when higher threshold",
+			a:    newCrashLoopPolicy("a", withRestartThreshold(20)),
+			b:    newCrashLoopPolicy("b", withRestartThreshold(2)),
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isMoreRestrictive(tc.a, tc.b); got != tc.want {
+				t.Errorf("isMoreRestrictive() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -338,7 +338,7 @@ func allReplicasFailing(ctx context.Context, c client.Client, owner *ownerWorklo
 
 // scaleDownWorkload scales a workload to zero or suspends it.
 // It uses RetryOnConflict to handle concurrent updates safely.
-func scaleDownWorkload(ctx context.Context, c client.Client, owner *ownerWorkload, reason string, dryRun bool) (bool, error) {
+func scaleDownWorkload(ctx context.Context, c client.Client, owner *ownerWorkload, reason, policyName string, dryRun bool) (bool, error) {
 	now := time.Now().UTC().Format(time.RFC3339)
 	key := types.NamespacedName{Name: owner.Name, Namespace: owner.Namespace}
 
@@ -371,6 +371,7 @@ func scaleDownWorkload(ctx context.Context, c client.Client, owner *ownerWorkloa
 			}
 			deploy.Annotations[AnnotationScaledDownReason] = reason
 			deploy.Annotations[AnnotationScaledDownAt] = now
+			deploy.Annotations[AnnotationScaledDownBy] = policyName
 			deploy.Annotations[AnnotationPreviousReplicas] = fmt.Sprintf("%d", prevReplicas)
 			return c.Update(ctx, deploy)
 		})
@@ -407,6 +408,7 @@ func scaleDownWorkload(ctx context.Context, c client.Client, owner *ownerWorkloa
 			}
 			sts.Annotations[AnnotationScaledDownReason] = reason
 			sts.Annotations[AnnotationScaledDownAt] = now
+			sts.Annotations[AnnotationScaledDownBy] = policyName
 			sts.Annotations[AnnotationPreviousReplicas] = fmt.Sprintf("%d", prevReplicas)
 			return c.Update(ctx, sts)
 		})
@@ -439,6 +441,7 @@ func scaleDownWorkload(ctx context.Context, c client.Client, owner *ownerWorkloa
 			}
 			cj.Annotations[AnnotationScaledDownReason] = reason
 			cj.Annotations[AnnotationScaledDownAt] = now
+			cj.Annotations[AnnotationScaledDownBy] = policyName
 			return c.Update(ctx, cj)
 		})
 		if err != nil {
@@ -452,7 +455,7 @@ func scaleDownWorkload(ctx context.Context, c client.Client, owner *ownerWorkloa
 
 // findActiveScaledDownWorkloads returns workload keys for all workloads that carry
 // the crashloop-operator scaled-down annotation, filtered by namespace and targets.
-func findActiveScaledDownWorkloads(ctx context.Context, c client.Client, allowedNamespaces map[string]bool, excludeNamespaces, targets []string) ([]crashloopv1alpha1.ScaledDownWorkloadRef, error) {
+func findActiveScaledDownWorkloads(ctx context.Context, c client.Client, allowedNamespaces map[string]bool, excludeNamespaces, targets []string, policyName string) ([]crashloopv1alpha1.ScaledDownWorkloadRef, error) {
 	var active []crashloopv1alpha1.ScaledDownWorkloadRef
 
 	if isTargetKind("Deployment", targets) {
@@ -463,6 +466,10 @@ func findActiveScaledDownWorkloads(ctx context.Context, c client.Client, allowed
 		for i := range deployList.Items {
 			d := &deployList.Items[i]
 			if d.Annotations[AnnotationScaledDownReason] == "" {
+				continue
+			}
+			// Only report workloads this policy scaled down itself.
+			if d.Annotations[AnnotationScaledDownBy] != policyName {
 				continue
 			}
 			if isExcludedNamespace(d.Namespace, excludeNamespaces) {
@@ -489,6 +496,10 @@ func findActiveScaledDownWorkloads(ctx context.Context, c client.Client, allowed
 			if s.Annotations[AnnotationScaledDownReason] == "" {
 				continue
 			}
+			// Only report workloads this policy scaled down itself.
+			if s.Annotations[AnnotationScaledDownBy] != policyName {
+				continue
+			}
 			if isExcludedNamespace(s.Namespace, excludeNamespaces) {
 				continue
 			}
@@ -511,6 +522,10 @@ func findActiveScaledDownWorkloads(ctx context.Context, c client.Client, allowed
 		for i := range cjList.Items {
 			cj := &cjList.Items[i]
 			if cj.Annotations[AnnotationScaledDownReason] == "" {
+				continue
+			}
+			// Only report workloads this policy scaled down itself.
+			if cj.Annotations[AnnotationScaledDownBy] != policyName {
 				continue
 			}
 			if isExcludedNamespace(cj.Namespace, excludeNamespaces) {

--- a/internal/controller/policyresolve.go
+++ b/internal/controller/policyresolve.go
@@ -1,0 +1,192 @@
+package controller
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	crashloopv1alpha1 "github.com/slauger/crashloop-operator/api/v1alpha1"
+)
+
+// Effective spec accessors. The API server applies the kubebuilder defaults,
+// but objects can reach the controller without having gone through defaulting
+// (an old object, or a unit test), so every read of a defaulted field goes
+// through one of these rather than repeating the fallback at each call site.
+
+func effectiveWatchReasons(p *crashloopv1alpha1.CrashLoopPolicy) []string {
+	if len(p.Spec.WatchReasons) > 0 {
+		return p.Spec.WatchReasons
+	}
+	return DefaultWatchReasons
+}
+
+func effectiveTargets(p *crashloopv1alpha1.CrashLoopPolicy) []string {
+	if len(p.Spec.Targets) > 0 {
+		return p.Spec.Targets
+	}
+	return DefaultTargets
+}
+
+func effectiveRestartThreshold(p *crashloopv1alpha1.CrashLoopPolicy) int32 {
+	if p.Spec.RestartThreshold > 0 {
+		return p.Spec.RestartThreshold
+	}
+	return DefaultRestartThreshold
+}
+
+func effectiveDurationThreshold(p *crashloopv1alpha1.CrashLoopPolicy) time.Duration {
+	return parseDuration(p.Spec.DurationThreshold)
+}
+
+func effectiveAllReplicasFailing(p *crashloopv1alpha1.CrashLoopPolicy) bool {
+	if p.Spec.AllReplicasFailing != nil {
+		return *p.Spec.AllReplicasFailing
+	}
+	return true
+}
+
+func effectiveDryRun(p *crashloopv1alpha1.CrashLoopPolicy) bool {
+	return p.Spec.DryRun != nil && *p.Spec.DryRun
+}
+
+// isMoreRestrictive reports whether a would act on a workload sooner, or more
+// forcefully, than b. The comparison is a total order so that the winner among
+// a set of matching policies is deterministic and independent of list order:
+//
+//  1. lower restartThreshold
+//  2. shorter durationThreshold
+//  3. allReplicasFailing false before true (acts on partial failure too)
+//  4. dryRun false before true (a real action outranks a simulated one)
+//  5. name ascending, purely to break remaining ties
+func isMoreRestrictive(a, b *crashloopv1alpha1.CrashLoopPolicy) bool {
+	if ra, rb := effectiveRestartThreshold(a), effectiveRestartThreshold(b); ra != rb {
+		return ra < rb
+	}
+	if da, db := effectiveDurationThreshold(a), effectiveDurationThreshold(b); da != db {
+		return da < db
+	}
+	if aa, ab := effectiveAllReplicasFailing(a), effectiveAllReplicasFailing(b); aa != ab {
+		return !aa
+	}
+	if wa, wb := effectiveDryRun(a), effectiveDryRun(b); wa != wb {
+		return !wa
+	}
+	return a.Name < b.Name
+}
+
+// namespaceResolver caches namespaceSelector lookups for one reconcile pass, so
+// that comparing N policies does not issue N namespace lists.
+type namespaceResolver struct {
+	client client.Client
+	cache  map[string]map[string]bool
+}
+
+func newNamespaceResolver(c client.Client) *namespaceResolver {
+	return &namespaceResolver{client: c, cache: make(map[string]map[string]bool)}
+}
+
+// allowed returns the namespaces admitted by the policy's selector, or nil when
+// the policy has no selector and therefore admits all of them.
+func (nr *namespaceResolver) allowed(ctx context.Context, p *crashloopv1alpha1.CrashLoopPolicy) (map[string]bool, error) {
+	if p.Spec.NamespaceSelector == nil {
+		return nil, nil
+	}
+	if cached, ok := nr.cache[p.Name]; ok {
+		return cached, nil
+	}
+	resolved, err := resolveNamespaces(ctx, nr.client, p.Spec.NamespaceSelector)
+	if err != nil {
+		return nil, err
+	}
+	nr.cache[p.Name] = resolved
+	return resolved, nil
+}
+
+// policyWouldAct reports whether the policy would scale down owner right now,
+// given the failing pod that led to it. It runs the same checks the reconcile
+// loop applies to its own policy, so that the winner is chosen among policies
+// that would genuinely act rather than merely reference the same namespace.
+func policyWouldAct(
+	ctx context.Context,
+	c client.Client,
+	nr *namespaceResolver,
+	policy *crashloopv1alpha1.CrashLoopPolicy,
+	pod *corev1.Pod,
+	owner *ownerWorkload,
+) (bool, error) {
+	allowedNamespaces, err := nr.allowed(ctx, policy)
+	if err != nil {
+		return false, err
+	}
+	if allowedNamespaces != nil && !allowedNamespaces[pod.Namespace] {
+		return false, nil
+	}
+	if isExcludedNamespace(pod.Namespace, policy.Spec.ExcludeNamespaces) {
+		return false, nil
+	}
+	if !isTargetKind(owner.Kind, effectiveTargets(policy)) {
+		return false, nil
+	}
+
+	watchReasons := effectiveWatchReasons(policy)
+	if _, failing := podHasFailureReason(pod, watchReasons); !failing {
+		return false, nil
+	}
+	if !podExceedsRestartThreshold(pod, effectiveRestartThreshold(policy)) &&
+		!podExceedsDurationThreshold(pod, effectiveDurationThreshold(policy)) {
+		return false, nil
+	}
+
+	if policy.Spec.ExcludeWorkloadSelector != nil {
+		excluded, err := isWorkloadExcludedBySelector(ctx, c, owner, policy.Spec.ExcludeWorkloadSelector)
+		if err != nil {
+			return false, err
+		}
+		if excluded {
+			return false, nil
+		}
+	}
+
+	if effectiveAllReplicasFailing(policy) {
+		allFailing, err := allReplicasFailing(ctx, c, owner, watchReasons)
+		if err != nil {
+			return false, err
+		}
+		if !allFailing {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// winningPolicy returns the most restrictive policy that would act on owner for
+// the given pod. It returns nil when no policy would act. Policies other than
+// the winner leave the workload alone, so a workload is scaled down once, by one
+// identifiable policy, no matter how many policies overlap.
+func winningPolicy(
+	ctx context.Context,
+	c client.Client,
+	nr *namespaceResolver,
+	policies []crashloopv1alpha1.CrashLoopPolicy,
+	pod *corev1.Pod,
+	owner *ownerWorkload,
+) (*crashloopv1alpha1.CrashLoopPolicy, error) {
+	var winner *crashloopv1alpha1.CrashLoopPolicy
+	for i := range policies {
+		candidate := &policies[i]
+		acts, err := policyWouldAct(ctx, c, nr, candidate, pod, owner)
+		if err != nil {
+			return nil, err
+		}
+		if !acts {
+			continue
+		}
+		if winner == nil || isMoreRestrictive(candidate, winner) {
+			winner = candidate
+		}
+	}
+	return winner, nil
+}


### PR DESCRIPTION
## Summary

Policies are cluster-scoped and every policy evaluates every workload, so several can match the same one. Previously each acted independently: the scale-down was attributed to whichever policy got there first, and every policy reported every scaled-down workload in its own `activeScaledDown` regardless of which one caused it.

This implements the recorded decision that the most restrictive policy wins, taking it literally: one policy wins the workload wholesale, rather than merging fields from several into a synthetic effective policy. That is simpler to reason about and to document.

- **Candidates are policies that would act right now.** A policy whose `watchReasons` do not cover the observed failure, or whose thresholds are not yet exceeded, cannot win and therefore cannot block a policy that would act. Selecting on mere namespace overlap would have let an inert policy stall a live one.
- **A total order picks the winner**: lower `restartThreshold`, then shorter `durationThreshold`, then `allReplicasFailing: false`, then `dryRun: false`, then name. Because it is total, the winner does not depend on the order policies happen to be evaluated in.
- **Attribution** via a new `scaled-down-by` annotation. `findActiveScaledDownWorkloads` filters on it, so status lists and the lifetime counter reflect only what each policy actually did.

Also folds the defaulting fallbacks into `effective*` accessors. They were duplicated between the CRD markers and inline code in `Reconcile`, and the comparison needs the same values, so a third copy would have been worse.

One tradeoff worth flagging: resolving the winner evaluates the other policies per candidate workload, so cost scales with the number of policies. Namespace selector lookups are cached per reconcile pass to keep that from multiplying API calls, but the broader loop efficiency work is #29.

Closes #20

## Test plan

- `make ci` passes locally end to end; coverage rose from 55.3 to 57.8 percent.
- New tests: the less restrictive policy defers while the more restrictive one scales down and stamps `scaled-down-by`; the owning policy lists the workload and counts it while the other policy's list and counter stay empty; and a table test covering each tier of the ordering including the name tiebreak.