### PR TITLE
feat(api): validate duration fields at the API level

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ Short name: `clp` (`kubectl get clp`).
 |---|---|---|
 | `watchReasons` | `[CrashLoopBackOff, ImagePullBackOff, ErrImagePull, CreateContainerConfigError, InvalidImageName, RunContainerError]` | Container waiting reasons to watch |
 | `restartThreshold` | `10` | Number of container restarts before action |
-| `durationThreshold` | `30m` | How long a pod must be failing before action |
+| `durationThreshold` | `30m` | How long a pod must be failing before action. Go duration format, rejected by the API server if malformed |
 | `allReplicasFailing` | `true` | Require all replicas to be failing |
 | `targets` | `[Deployment, StatefulSet, CronJob]` | Workload types to act on. Only these three values are accepted |
 | `namespaceSelector` | `nil` | Label selector for namespaces to watch (nil = all) |
 | `excludeNamespaces` | `[kube-system, kube-public, kube-node-lease]` | Namespaces to ignore (applied after namespaceSelector) |
 | `excludeWorkloadSelector` | `nil` | Label selector to exclude matching workloads from scale-down |
-| `reconcileInterval` | `60s` | How often the policy is evaluated |
+| `reconcileInterval` | `60s` | How often the policy is evaluated. Same duration format as `durationThreshold` |
 | `dryRun` | `false` | Log actions without executing them |
 
 ### Status

--- a/api/v1alpha1/crashlooppolicy_types.go
+++ b/api/v1alpha1/crashlooppolicy_types.go
@@ -25,7 +25,11 @@ type CrashLoopPolicySpec struct {
 	RestartThreshold int32 `json:"restartThreshold,omitempty"`
 
 	// DurationThreshold is how long a pod must be failing before action (e.g. "30m").
+	// Accepts a Go duration: one or more number+unit pairs, where the unit is
+	// ns, us, ms, s, m or h. The non-ASCII spellings of microseconds that Go
+	// also accepts are deliberately not permitted.
 	// +kubebuilder:default="30m"
+	// +kubebuilder:validation:Pattern=`^([0-9]+(\.[0-9]+)?(ns|us|ms|s|m|h))+$`
 	DurationThreshold string `json:"durationThreshold,omitempty"`
 
 	// AllReplicasFailing requires all replicas to be failing before action.
@@ -56,8 +60,9 @@ type CrashLoopPolicySpec struct {
 	ExcludeWorkloadSelector *metav1.LabelSelector `json:"excludeWorkloadSelector,omitempty"`
 
 	// ReconcileInterval is how often the policy is evaluated (e.g. "60s", "5m").
-	// Defaults to "60s" if not set.
+	// Defaults to "60s" if not set. Same duration format as DurationThreshold.
 	// +kubebuilder:default="60s"
+	// +kubebuilder:validation:Pattern=`^([0-9]+(\.[0-9]+)?(ns|us|ms|s|m|h))+$`
 	ReconcileInterval string `json:"reconcileInterval,omitempty"`
 
 	// DryRun logs actions without executing them.

--- a/charts/crashloop-operator/crds/crashloop-operator.lauger.de_crashlooppolicies.yaml
+++ b/charts/crashloop-operator/crds/crashloop-operator.lauger.de_crashlooppolicies.yaml
@@ -68,8 +68,12 @@ spec:
                 type: boolean
               durationThreshold:
                 default: 30m
-                description: DurationThreshold is how long a pod must be failing before
-                  action (e.g. "30m").
+                description: |-
+                  DurationThreshold is how long a pod must be failing before action (e.g. "30m").
+                  Accepts a Go duration: one or more number+unit pairs, where the unit is
+                  ns, us, ms, s, m or h. The non-ASCII spellings of microseconds that Go
+                  also accepts are deliberately not permitted.
+                pattern: ^([0-9]+(\.[0-9]+)?(ns|us|ms|s|m|h))+$
                 type: string
               excludeNamespaces:
                 default:
@@ -182,7 +186,8 @@ spec:
                 default: 60s
                 description: |-
                   ReconcileInterval is how often the policy is evaluated (e.g. "60s", "5m").
-                  Defaults to "60s" if not set.
+                  Defaults to "60s" if not set. Same duration format as DurationThreshold.
+                pattern: ^([0-9]+(\.[0-9]+)?(ns|us|ms|s|m|h))+$
                 type: string
               restartThreshold:
                 default: 10

--- a/config/crd/bases/crashloop-operator.lauger.de_crashlooppolicies.yaml
+++ b/config/crd/bases/crashloop-operator.lauger.de_crashlooppolicies.yaml
@@ -68,8 +68,12 @@ spec:
                 type: boolean
               durationThreshold:
                 default: 30m
-                description: DurationThreshold is how long a pod must be failing before
-                  action (e.g. "30m").
+                description: |-
+                  DurationThreshold is how long a pod must be failing before action (e.g. "30m").
+                  Accepts a Go duration: one or more number+unit pairs, where the unit is
+                  ns, us, ms, s, m or h. The non-ASCII spellings of microseconds that Go
+                  also accepts are deliberately not permitted.
+                pattern: ^([0-9]+(\.[0-9]+)?(ns|us|ms|s|m|h))+$
                 type: string
               excludeNamespaces:
                 default:
@@ -182,7 +186,8 @@ spec:
                 default: 60s
                 description: |-
                   ReconcileInterval is how often the policy is evaluated (e.g. "60s", "5m").
-                  Defaults to "60s" if not set.
+                  Defaults to "60s" if not set. Same duration format as DurationThreshold.
+                pattern: ^([0-9]+(\.[0-9]+)?(ns|us|ms|s|m|h))+$
                 type: string
               restartThreshold:
                 default: 10

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -15,6 +15,9 @@ const (
 	DefaultDurationThreshold = "30m"
 )
 
+// DefaultDurationThresholdDuration is DefaultDurationThreshold as a duration.
+const DefaultDurationThresholdDuration = 30 * time.Minute
+
 // DefaultWatchReasons mirrors the kubebuilder default on spec.watchReasons.
 var DefaultWatchReasons = []string{
 	"CrashLoopBackOff",

--- a/internal/controller/crashlooppolicy_controller.go
+++ b/internal/controller/crashlooppolicy_controller.go
@@ -55,6 +55,18 @@ func (r *CrashLoopPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 	}
 
+	// Both duration fields are pattern-validated by the API server, so an
+	// unparseable value here means an object that predates that validation.
+	// Say so rather than quietly running on the default.
+	if _, ok := parseDuration(policy.Spec.DurationThreshold, DefaultDurationThresholdDuration); policy.Spec.DurationThreshold != "" && !ok {
+		logger.Info("invalid durationThreshold, using default",
+			"value", policy.Spec.DurationThreshold, "default", DefaultDurationThreshold)
+	}
+	if _, ok := effectiveReconcileInterval(policy); !ok {
+		logger.Info("invalid reconcileInterval, using default",
+			"value", policy.Spec.ReconcileInterval, "default", RequeueIntervalDefault)
+	}
+
 	durationThreshold := effectiveDurationThreshold(policy)
 	watchReasons := effectiveWatchReasons(policy)
 	restartThreshold := effectiveRestartThreshold(policy)
@@ -264,10 +276,7 @@ func (r *CrashLoopPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	// Use per-policy reconcile interval if configured
-	requeueInterval := parseDuration(policy.Spec.ReconcileInterval)
-	if requeueInterval <= 0 {
-		requeueInterval = RequeueIntervalDefault
-	}
+	requeueInterval, _ := effectiveReconcileInterval(policy)
 
 	return ctrl.Result{RequeueAfter: requeueInterval}, nil
 }

--- a/internal/controller/crashlooppolicy_controller_test.go
+++ b/internal/controller/crashlooppolicy_controller_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"regexp"
 	"testing"
 	"time"
 
@@ -906,5 +907,81 @@ func TestIsMoreRestrictive(t *testing.T) {
 				t.Errorf("isMoreRestrictive() = %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestParseDuration(t *testing.T) {
+	fallback := 42 * time.Second
+	tests := []struct {
+		name  string
+		input string
+		want  time.Duration
+		wantO bool
+	}{
+		{name: "simple", input: "30m", want: 30 * time.Minute, wantO: true},
+		{name: "compound", input: "1h30m", want: 90 * time.Minute, wantO: true},
+		{name: "fractional", input: "0.5h", want: 30 * time.Minute, wantO: true},
+		{name: "milliseconds", input: "500ms", want: 500 * time.Millisecond, wantO: true},
+		{name: "empty falls back", input: "", want: fallback, wantO: false},
+		{name: "prose falls back", input: "2 hours", want: fallback, wantO: false},
+		{name: "unit missing falls back", input: "30", want: fallback, wantO: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseDuration(tc.input, fallback)
+			if got != tc.want || ok != tc.wantO {
+				t.Errorf("parseDuration(%q) = (%v, %v), want (%v, %v)", tc.input, got, ok, tc.want, tc.wantO)
+			}
+		})
+	}
+}
+
+func TestEffectiveReconcileInterval(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  time.Duration
+		wantO bool
+	}{
+		{name: "unset uses default", value: "", want: RequeueIntervalDefault, wantO: true},
+		{name: "valid is honoured", value: "5m", want: 5 * time.Minute, wantO: true},
+		// Regression: the old code fell back to the 30m durationThreshold
+		// default here, so a typo silently produced a 30 minute loop.
+		{name: "invalid uses the reconcile default", value: "5 minutes", want: RequeueIntervalDefault, wantO: false},
+		{name: "zero uses the reconcile default", value: "0s", want: RequeueIntervalDefault, wantO: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := newCrashLoopPolicy("p", withReconcileInterval(tc.value))
+			got, ok := effectiveReconcileInterval(p)
+			if got != tc.want || ok != tc.wantO {
+				t.Errorf("effectiveReconcileInterval(%q) = (%v, %v), want (%v, %v)", tc.value, got, ok, tc.want, tc.wantO)
+			}
+		})
+	}
+}
+
+func TestDurationPatternMatchesAcceptedValues(t *testing.T) {
+	// Mirrors the kubebuilder Pattern on durationThreshold and
+	// reconcileInterval. Anything the pattern admits must also parse, and the
+	// documented defaults must be admitted.
+	pattern := regexp.MustCompile(`^([0-9]+(\.[0-9]+)?(ns|us|ms|s|m|h))+$`)
+
+	valid := []string{"30m", "60s", "1h", "1h30m", "0.5h", "500ms", "100us", "10ns"}
+	for _, v := range valid {
+		if !pattern.MatchString(v) {
+			t.Errorf("pattern should accept %q", v)
+			continue
+		}
+		if _, err := time.ParseDuration(v); err != nil {
+			t.Errorf("pattern accepts %q but time.ParseDuration rejects it: %v", v, err)
+		}
+	}
+
+	invalid := []string{"2 hours", "30", "", "abc", "-5m", "5 m", "1d"}
+	for _, v := range invalid {
+		if pattern.MatchString(v) {
+			t.Errorf("pattern should reject %q", v)
+		}
 	}
 }

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -212,13 +212,21 @@ func workloadKey(w *ownerWorkload) string {
 	return fmt.Sprintf("%s/%s/%s", w.Namespace, w.Kind, w.Name)
 }
 
-// parseDuration parses a duration string, falling back to the default.
-func parseDuration(s string) time.Duration {
+// parseDuration parses a duration string, falling back to the caller's default
+// and reporting whether the input was usable. The fallback is a parameter
+// because the two duration fields have different defaults; hardcoding one of
+// them made an invalid reconcileInterval silently run at the 30m threshold
+// default instead of 60s.
+//
+// The API server rejects malformed values through the Pattern on both fields,
+// so a false return means either an object written before that validation
+// existed or a value the pattern admits but time.ParseDuration does not.
+func parseDuration(s string, fallback time.Duration) (time.Duration, bool) {
 	d, err := time.ParseDuration(s)
 	if err != nil {
-		d, _ = time.ParseDuration(DefaultDurationThreshold)
+		return fallback, false
 	}
-	return d
+	return d, true
 }
 
 // allReplicasFailing checks if all pods of a workload are in a failing state.

--- a/internal/controller/policyresolve.go
+++ b/internal/controller/policyresolve.go
@@ -37,7 +37,21 @@ func effectiveRestartThreshold(p *crashloopv1alpha1.CrashLoopPolicy) int32 {
 }
 
 func effectiveDurationThreshold(p *crashloopv1alpha1.CrashLoopPolicy) time.Duration {
-	return parseDuration(p.Spec.DurationThreshold)
+	d, _ := parseDuration(p.Spec.DurationThreshold, DefaultDurationThresholdDuration)
+	return d
+}
+
+// effectiveReconcileInterval returns the requeue period for the policy, falling
+// back to the default when unset or unparseable.
+func effectiveReconcileInterval(p *crashloopv1alpha1.CrashLoopPolicy) (time.Duration, bool) {
+	if p.Spec.ReconcileInterval == "" {
+		return RequeueIntervalDefault, true
+	}
+	d, ok := parseDuration(p.Spec.ReconcileInterval, RequeueIntervalDefault)
+	if !ok || d <= 0 {
+		return RequeueIntervalDefault, ok && d > 0
+	}
+	return d, true
 }
 
 func effectiveAllReplicasFailing(p *crashloopv1alpha1.CrashLoopPolicy) bool {


### PR DESCRIPTION
## Summary

`durationThreshold` and `reconcileInterval` accepted any string. An invalid value such as `"2 hours"` was swallowed by `parseDuration` and the policy silently ran on a default the user never asked for.

I went with the issue's alternative, a `Pattern` marker, rather than the validating webhook. A webhook would need a Service, certificate plumbing and rotation, a `ValidatingWebhookConfiguration` in the chart, and a failure-policy decision, and it makes policy writes depend on the operator being up. That is a lot of moving parts and a new availability dependency for what is a string format check the API server can do declaratively. If semantic validation that markers cannot express comes up later, a webhook can be added then.

The other two checks the issue lists are already in place: `restartThreshold` has `Minimum=1`, and `targets` got an enum in #19.

**Second bug found along the way.** `parseDuration` hardcoded the `durationThreshold` default, so an unparseable `reconcileInterval` fell back to 30m instead of 60s, and the `<= 0` guard could not catch it because 30m is positive. A typo therefore turned a one minute reconcile loop into a thirty minute one. The fallback is now a parameter, and the reconcile interval resolves through its own accessor.

`parseDuration` additionally reports whether the input was usable, and the reconciler logs when it was not, so an object written before this validation existed surfaces rather than failing silently.

The pattern deliberately omits the non-ASCII spellings of microseconds that Go also accepts, keeping the sources ASCII-clean as the repo requires. `us` still works.

Closes #4

## Test plan

- `make ci` passes locally end to end; coverage rose from 57.8 to 58.3 percent.
- New table tests for `parseDuration` (valid, compound, fractional, and the fallback cases) and for `effectiveReconcileInterval`, including the 30m regression above.
- A test mirrors the Pattern regex and asserts both directions: everything the pattern admits also parses with `time.ParseDuration`, and prose, bare numbers, negatives and `1d` are rejected.
- Verified the pattern reaches the generated CRD on both fields.