### PR TITLE
perf(controller): index failing pods, filter pod events, surface partial failures

### DIFF
--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -5,7 +5,6 @@ import "time"
 // Requeue intervals for controller reconciliation loops.
 const (
 	RequeueIntervalDefault = 60 * time.Second
-	RequeueIntervalShort   = 10 * time.Second
 )
 
 // Default thresholds. These mirror the kubebuilder defaults on the CRD fields
@@ -51,7 +50,6 @@ const (
 	EventReasonScaledDown = "WorkloadScaledDown"
 	EventReasonSuspended  = "WorkloadSuspended"
 	EventReasonDryRun     = "WorkloadScaleDownDryRun"
-	EventReasonEvaluated  = "PolicyEvaluated"
 )
 
 // Condition types for CrashLoopPolicy status.

--- a/internal/controller/crashlooppolicy_controller.go
+++ b/internal/controller/crashlooppolicy_controller.go
@@ -11,9 +11,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	crashloopv1alpha1 "github.com/slauger/crashloop-operator/api/v1alpha1"
@@ -91,19 +93,25 @@ func (r *CrashLoopPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
-	// List all pods across all namespaces
-	podList := &corev1.PodList{}
-	if err := r.List(ctx, podList); err != nil {
-		logger.Error(err, "failed to list pods")
+	// Ask the cache only for pods waiting on one of the reasons this policy
+	// watches. Listing every pod in the cluster and discarding the healthy
+	// ones does not scale with cluster size.
+	pods, err := listPodsByWaitingReasons(ctx, r.Client, watchReasons)
+	if err != nil {
+		logger.Error(err, "failed to list failing pods")
 		return ctrl.Result{}, err
 	}
 
 	// Track which workloads we have already processed
 	processed := make(map[string]bool)
 	scaledDown := int32(0)
+	// Errors inside the loop are per-workload and must not abort the whole
+	// evaluation, but they must not vanish either: they are counted here and
+	// reported through the Ready condition.
+	loopErrors := 0
 
-	for i := range podList.Items {
-		pod := &podList.Items[i]
+	for i := range pods {
+		pod := &pods[i]
 
 		// Skip namespaces not matching the selector (if set)
 		if allowedNamespaces != nil {
@@ -134,6 +142,7 @@ func (r *CrashLoopPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		owner, err := resolveOwnerWorkload(ctx, r.Client, pod)
 		if err != nil {
 			logger.Error(err, "failed to resolve owner workload", "pod", pod.Name, "namespace", pod.Namespace)
+			loopErrors++
 			continue
 		}
 		if owner == nil {
@@ -157,6 +166,7 @@ func (r *CrashLoopPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			excluded, err := isWorkloadExcludedBySelector(ctx, r.Client, owner, policy.Spec.ExcludeWorkloadSelector)
 			if err != nil {
 				logger.Error(err, "failed to check workload selector", "workload", key)
+				loopErrors++
 				continue
 			}
 			if excluded {
@@ -170,6 +180,7 @@ func (r *CrashLoopPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			allFailing, err := allReplicasFailing(ctx, r.Client, owner, watchReasons)
 			if err != nil {
 				logger.Error(err, "failed to check all replicas", "workload", key)
+				loopErrors++
 				continue
 			}
 			if !allFailing {
@@ -184,6 +195,7 @@ func (r *CrashLoopPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		winner, err := winningPolicy(ctx, r.Client, nsResolver, policyList.Items, pod, owner)
 		if err != nil {
 			logger.Error(err, "failed to resolve winning policy", "workload", key)
+			loopErrors++
 			continue
 		}
 		if winner != nil && winner.Name != policy.Name {
@@ -197,6 +209,7 @@ func (r *CrashLoopPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		acted, err := scaleDownWorkload(ctx, r.Client, owner, scaleReason, policy.Name, dryRun)
 		if err != nil {
 			logger.Error(err, "failed to scale down workload", "workload", key)
+			loopErrors++
 			continue
 		}
 
@@ -217,10 +230,13 @@ func (r *CrashLoopPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 	}
 
-	// Collect currently active scaled-down workloads
+	// Collect currently active scaled-down workloads. A failure here leaves the
+	// list incomplete rather than empty, so it counts as a partial failure
+	// instead of silently truncating status.
 	activeScaledDown, err := findActiveScaledDownWorkloads(ctx, r.Client, allowedNamespaces, policy.Spec.ExcludeNamespaces, targets, policy.Name)
 	if err != nil {
 		logger.Error(err, "failed to find active scaled-down workloads")
+		loopErrors++
 	}
 
 	truncated := int32(0)
@@ -244,13 +260,22 @@ func (r *CrashLoopPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		policy.Status.ActiveScaledDown = activeScaledDown
 		policy.Status.ActiveScaledDownTruncated = truncated
 
-		// Set Ready condition
+		// Ready reflects whether the evaluation actually completed. It used to
+		// be set to True unconditionally, which hid every per-workload failure.
+		readyStatus := metav1.ConditionTrue
+		readyReason := "ReconcileSucceeded"
+		readyMessage := "Policy evaluation completed successfully"
+		if loopErrors > 0 {
+			readyStatus = metav1.ConditionFalse
+			readyReason = "ReconcilePartiallyFailed"
+			readyMessage = fmt.Sprintf("Policy evaluation completed with %d error(s); see operator logs", loopErrors)
+		}
 		meta.SetStatusCondition(&policy.Status.Conditions, metav1.Condition{
 			Type:               ConditionReady,
-			Status:             metav1.ConditionTrue,
+			Status:             readyStatus,
 			ObservedGeneration: generation,
-			Reason:             "ReconcileSucceeded",
-			Message:            "Policy evaluation completed successfully",
+			Reason:             readyReason,
+			Message:            readyMessage,
 		})
 
 		// Set Degraded condition based on whether workloads are scaled down
@@ -283,10 +308,28 @@ func (r *CrashLoopPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *CrashLoopPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(), &corev1.Pod{}, IndexPodWaitingReason, podWaitingReasons,
+	); err != nil {
+		return err
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&crashloopv1alpha1.CrashLoopPolicy{}).
-		Watches(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(r.mapPodToPolicy)).
+		Watches(
+			&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(r.mapPodToPolicy),
+			// Healthy pods vastly outnumber stuck ones and cannot trigger an
+			// action, so filtering them out here keeps the queue quiet.
+			builder.WithPredicates(predicate.NewPredicateFuncs(podHasWaitingContainer)),
+		).
 		Complete(r)
+}
+
+// podHasWaitingContainer reports whether any container is waiting with a
+// reason, which is the precondition for a pod being interesting to any policy.
+func podHasWaitingContainer(obj client.Object) bool {
+	return len(podWaitingReasons(obj)) > 0
 }
 
 // mapPodToPolicy maps a pod event to the CrashLoopPolicy objects that should be reconciled.
@@ -310,18 +353,11 @@ func (r *CrashLoopPolicyReconciler) mapPodToPolicy(ctx context.Context, obj clie
 			continue
 		}
 
-		// Skip if policy has a namespace selector and the pod's namespace doesn't match
-		if policy.Spec.NamespaceSelector != nil {
-			allowed, err := resolveNamespaces(ctx, r.Client, policy.Spec.NamespaceSelector)
-			if err != nil {
-				logger.Error(err, "failed to resolve namespace selector in mapPodToPolicy", "policy", policy.Name)
-				continue
-			}
-			if allowed != nil && !allowed[podNamespace] {
-				continue
-			}
-		}
-
+		// Deliberately no namespaceSelector check here. Resolving it costs a
+		// namespace list per policy per event, and this function only decides
+		// whether to enqueue: Reconcile applies the selector properly anyway.
+		// Enqueuing a reconcile that finds nothing is far cheaper, especially
+		// since the watch predicate already filters out healthy pods.
 		requests = append(requests, reconcile.Request{
 			NamespacedName: client.ObjectKeyFromObject(policy),
 		})

--- a/internal/controller/crashlooppolicy_controller_test.go
+++ b/internal/controller/crashlooppolicy_controller_test.go
@@ -677,9 +677,13 @@ func TestMapPodToPolicy_NamespaceSelectorFilters(t *testing.T) {
 		t.Errorf("expected 1 request for pod in dev namespace, got %d", len(devRequests))
 	}
 
+	// The map function deliberately does not resolve the namespaceSelector:
+	// doing so cost a namespace list per policy per pod event. It only decides
+	// whether to enqueue, and Reconcile applies the selector for real, as
+	// TestReconcile_NamespaceSelectorFilters asserts.
 	prodRequests := r.mapPodToPolicy(testCtx(), prodPod)
-	if len(prodRequests) != 0 {
-		t.Errorf("expected 0 requests for pod in prod namespace (not matching selector), got %d", len(prodRequests))
+	if len(prodRequests) != 1 {
+		t.Errorf("expected the pod to be enqueued and filtered during reconcile, got %d requests", len(prodRequests))
 	}
 }
 
@@ -983,5 +987,79 @@ func TestDurationPatternMatchesAcceptedValues(t *testing.T) {
 		if pattern.MatchString(v) {
 			t.Errorf("pattern should reject %q", v)
 		}
+	}
+}
+
+func TestPodWaitingReasons(t *testing.T) {
+	healthy := newHealthyPod("healthy", testNamespace, rsOwnerRef())
+	if got := podWaitingReasons(healthy); len(got) != 0 {
+		t.Errorf("expected no reasons for a healthy pod, got %v", got)
+	}
+
+	failing := newFailingPod("failing", testNamespace, rsOwnerRef(), "CrashLoopBackOff", 3)
+	got := podWaitingReasons(failing)
+	if len(got) != 1 || got[0] != "CrashLoopBackOff" {
+		t.Errorf("expected [CrashLoopBackOff], got %v", got)
+	}
+
+	// A non-pod object must not panic the index function.
+	if got := podWaitingReasons(newDeployment("d", testNamespace, 1)); got != nil {
+		t.Errorf("expected nil for a non-pod object, got %v", got)
+	}
+}
+
+func TestPodHasWaitingContainer(t *testing.T) {
+	if podHasWaitingContainer(newHealthyPod("healthy", testNamespace, rsOwnerRef())) {
+		t.Error("healthy pod should not pass the watch predicate")
+	}
+	if !podHasWaitingContainer(newFailingPod("failing", testNamespace, rsOwnerRef(), "ImagePullBackOff", 1)) {
+		t.Error("failing pod should pass the watch predicate")
+	}
+}
+
+func TestListPodsByWaitingReasons_DeduplicatesAndFilters(t *testing.T) {
+	failing := newFailingPod("failing", testNamespace, rsOwnerRef(), "CrashLoopBackOff", 3)
+	healthy := newHealthyPod("healthy", testNamespace, rsOwnerRef())
+	c := setupTestClient(failing, healthy)
+
+	// Passing the reason twice must not yield the pod twice.
+	pods, err := listPodsByWaitingReasons(testCtx(), c, []string{"CrashLoopBackOff", "CrashLoopBackOff", "ImagePullBackOff"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pods) != 1 {
+		t.Fatalf("expected exactly 1 pod, got %d", len(pods))
+	}
+	if pods[0].Name != "failing" {
+		t.Errorf("expected the failing pod, got %s", pods[0].Name)
+	}
+}
+
+func TestReconcile_ReadyFalseOnPartialFailure(t *testing.T) {
+	// A pod owned by a ReplicaSet whose Deployment cannot be resolved makes
+	// resolveOwnerWorkload fail. The evaluation continues, but Ready must say
+	// so instead of reporting unconditional success.
+	policy := newCrashLoopPolicy("test-policy", withAllReplicasFailing(false))
+	pod := newFailingPod("orphan-pod", testNamespace, rsOwnerRef(), "CrashLoopBackOff", 15)
+	c := &failingOwnerClient{Client: setupTestClient(policy, pod)}
+	r := newReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("test-policy")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updated := &crashloopv1alpha1.CrashLoopPolicy{}
+	if err := c.Get(testCtx(), client.ObjectKey{Name: "test-policy"}, updated); err != nil {
+		t.Fatalf("failed to get policy: %v", err)
+	}
+	ready := meta.FindStatusCondition(updated.Status.Conditions, ConditionReady)
+	if ready == nil {
+		t.Fatal("expected Ready condition to be set")
+	}
+	if ready.Status != metav1.ConditionFalse {
+		t.Errorf("expected Ready=False after a partial failure, got %s", ready.Status)
+	}
+	if ready.Reason != "ReconcilePartiallyFailed" {
+		t.Errorf("expected reason ReconcilePartiallyFailed, got %s", ready.Reason)
 	}
 }

--- a/internal/controller/indexes.go
+++ b/internal/controller/indexes.go
@@ -1,0 +1,68 @@
+package controller
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// IndexPodWaitingReason indexes pods by the waiting reasons of their containers.
+// It lets the reconciler ask the cache for the handful of pods that are actually
+// stuck, instead of listing every pod in the cluster and discarding almost all
+// of them.
+const IndexPodWaitingReason = "status.waitingReason"
+
+// podWaitingReasons returns the distinct waiting reasons across a pod's
+// containers and init containers. A pod with no waiting container yields no
+// index entries and is therefore invisible to the indexed lookup.
+func podWaitingReasons(obj client.Object) []string {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	collect := func(statuses []corev1.ContainerStatus) {
+		for _, cs := range statuses {
+			if cs.State.Waiting != nil && cs.State.Waiting.Reason != "" {
+				seen[cs.State.Waiting.Reason] = struct{}{}
+			}
+		}
+	}
+	collect(pod.Status.ContainerStatuses)
+	collect(pod.Status.InitContainerStatuses)
+
+	if len(seen) == 0 {
+		return nil
+	}
+	reasons := make([]string, 0, len(seen))
+	for r := range seen {
+		reasons = append(reasons, r)
+	}
+	return reasons
+}
+
+// listPodsByWaitingReasons returns the pods matching any of the given waiting
+// reasons, deduplicated by UID since a pod can match several reasons at once.
+func listPodsByWaitingReasons(ctx context.Context, c client.Client, reasons []string) ([]corev1.Pod, error) {
+	var pods []corev1.Pod
+	seen := make(map[types.UID]struct{})
+
+	for _, reason := range reasons {
+		podList := &corev1.PodList{}
+		if err := c.List(ctx, podList, client.MatchingFields{IndexPodWaitingReason: reason}); err != nil {
+			return nil, err
+		}
+		for i := range podList.Items {
+			pod := podList.Items[i]
+			if _, dup := seen[pod.UID]; dup {
+				continue
+			}
+			seen[pod.UID] = struct{}{}
+			pods = append(pods, pod)
+		}
+	}
+	return pods, nil
+}

--- a/internal/controller/ptr.go
+++ b/internal/controller/ptr.go
@@ -1,9 +1,4 @@
 package controller
 
-const (
-	LabelManagedBy = "app.kubernetes.io/managed-by"
-	LabelName      = "app.kubernetes.io/name"
-)
-
 func int32Ptr(i int32) *int32 { return &i }
 func boolPtr(b bool) *bool    { return &b }

--- a/internal/controller/testutil_test.go
+++ b/internal/controller/testutil_test.go
@@ -2,11 +2,13 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -35,6 +37,9 @@ func setupTestClient(objs ...client.Object) client.Client {
 		WithStatusSubresource(
 			&crashloopv1alpha1.CrashLoopPolicy{},
 		).
+		// Mirrors the index SetupWithManager registers on the real cache, so
+		// tests exercise the same indexed lookup the operator uses.
+		WithIndex(&corev1.Pod{}, IndexPodWaitingReason, podWaitingReasons).
 		Build()
 }
 
@@ -347,4 +352,17 @@ func newReconciler(c client.Client) *CrashLoopPolicyReconciler {
 		Scheme:   testScheme(),
 		Recorder: testRecorder(),
 	}
+}
+
+// failingOwnerClient makes ReplicaSet reads fail so that resolveOwnerWorkload
+// returns an error, exercising the partial-failure path in Reconcile.
+type failingOwnerClient struct {
+	client.Client
+}
+
+func (f *failingOwnerClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if _, ok := obj.(*appsv1.ReplicaSet); ok {
+		return apierrors.NewInternalError(errors.New("simulated replicaset read failure"))
+	}
+	return f.Client.Get(ctx, key, obj, opts...)
 }


### PR DESCRIPTION
## Summary

- **Indexed pod lookup.** A new field index maps pods to their containers' waiting reasons, so the reconciler asks the cache for the handful of stuck pods rather than listing every pod in the cluster and discarding almost all of them. This replaces the O(all pods) scan per policy per interval.
- **Watch predicate.** Only pods with a waiting container enqueue a reconcile. Healthy pods vastly outnumber stuck ones and can never trigger an action, so they no longer wake the queue.
- **Cheaper mapping.** `mapPodToPolicy` no longer resolves `namespaceSelector`. It cost a namespace list per policy per pod event while only deciding whether to enqueue, and `Reconcile` applies the selector for real anyway. Enqueuing a reconcile that finds nothing is far cheaper than N namespace lists, especially now the predicate filters the events.
- **Honest Ready condition.** Per-workload errors were logged and swallowed while `Ready` was set `True` unconditionally, so a policy failing on every single workload still reported healthy. Errors are now counted and surfaced as `Ready=False` with reason `ReconcilePartiallyFailed`, without aborting the remaining work. A failure to collect the active scaled-down list counts too, since that previously truncated status in silence.
- **Dead code.** Removed `RequeueIntervalShort`, `EventReasonEvaluated` and the two unused label constants, and moved the pointer helpers out of `labels.go`, which had nothing to do with labels.

On the issue's suggestion to paginate: the reconciler reads through the controller-runtime cache, which serves whole informer stores and does not honour `Limit`/`Continue`, so pagination would have been a no-op. The index is the change that actually bounds the work, so I did that instead.

Closes #29

## Test plan

- `make ci` passes locally end to end; coverage rose from 58.3 to 60.1 percent.
- New tests cover the index function (healthy pod yields nothing, failing pod yields its reason, a non-pod object does not panic), the predicate, and deduplication when several watched reasons match the same pod.
- `TestReconcile_ReadyFalseOnPartialFailure` injects a client whose ReplicaSet reads fail, so owner resolution errors: the reconcile still completes but Ready flips to False with the new reason. This test fails on the previous code.
- The `mapPodToPolicy` namespace-selector test was rewritten to assert the new intent; `TestReconcile_NamespaceSelectorFilters` still covers that the selector is enforced where it matters.