### PR TITLE
test: add envtest API suite and a chainsaw e2e smoke test

### DIFF
--- a/.github/workflows/_go.yaml
+++ b/.github/workflows/_go.yaml
@@ -78,8 +78,17 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Download envtest assets
+        run: go tool setup-envtest use "${ENVTEST_K8S_VERSION}" -p path
+        env:
+          ENVTEST_K8S_VERSION: "1.37.0"
+
       - name: Run tests
-        run: go test ./... -race -covermode=atomic -coverprofile cover.out
+        run: |
+          KUBEBUILDER_ASSETS="$(go tool setup-envtest use "${ENVTEST_K8S_VERSION}" -p path)" \
+            go test ./... -race -covermode=atomic -coverprofile cover.out
+        env:
+          ENVTEST_K8S_VERSION: "1.37.0"
 
       - name: Check coverage threshold
         run: ./hack/check-coverage.sh cover.out 55

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,60 @@
+name: E2E
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths-ignore:
+      - "**/*.md"
+      - docs/**
+      - LICENSE
+      - CHANGELOG*
+      - .github/*.md
+  push:
+    branches: [develop]
+    paths-ignore:
+      - "**/*.md"
+      - docs/**
+      - LICENSE
+      - CHANGELOG*
+      - .github/*.md
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  chainsaw:
+    name: Chainsaw on kind
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: crashloop-e2e
+          config: tests/e2e/kind-config.yaml
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v5
+
+      - name: Build, load and install the operator
+        run: make e2e-deploy
+        env:
+          CONTAINER_TOOL: docker
+
+      - name: Run chainsaw tests
+        run: make e2e-run
+
+      - name: Dump operator logs on failure
+        if: failure()
+        run: |
+          kubectl -n crashloop-system get pods -o wide || true
+          kubectl -n crashloop-system logs -l app.kubernetes.io/name=crashloop-operator --tail=200 || true
+          kubectl get crashlooppolicies -o yaml || true

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ NAMESPACE ?= crashloop-system
 CONTAINER_TOOL ?= $(shell which podman 2>/dev/null || which docker 2>/dev/null)
 CONTROLLER_GEN = go tool controller-gen
 GOVULNCHECK = go tool govulncheck
+SETUP_ENVTEST = go tool setup-envtest
+ENVTEST_K8S_VERSION ?= 1.37.0
 COVERAGE_THRESHOLD ?= 55
 
 .PHONY: all
@@ -28,8 +30,13 @@ vet: ## Run go vet.
 	go vet ./...
 
 .PHONY: test
-test: manifests generate fmt vet ## Run tests.
-	go test ./... -race -covermode=atomic -coverprofile cover.out
+test: manifests generate fmt vet envtest-assets ## Run tests.
+	KUBEBUILDER_ASSETS="$$($(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" \
+		go test ./... -race -covermode=atomic -coverprofile cover.out
+
+.PHONY: envtest-assets
+envtest-assets: ## Download the envtest control plane binaries.
+	@$(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION) -p path >/dev/null
 
 .PHONY: check-coverage
 check-coverage: test ## Run tests and enforce the coverage threshold.
@@ -105,6 +112,52 @@ check-manifests: manifests generate ## Check for CRD and deepcopy drift.
 		git diff --stat -- $(GENERATED_PATHS); \
 		exit 1; \
 	fi
+
+##@ E2E
+
+# renovate: datasource=github-releases depName=kyverno/chainsaw
+CHAINSAW_VERSION ?= 0.2.15
+KIND_CLUSTER ?= crashloop-e2e
+CHAINSAW_OS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
+CHAINSAW_ARCH = $(shell uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')
+
+.PHONY: chainsaw
+chainsaw: ## Download the chainsaw CLI into bin/.
+	@test -x bin/chainsaw || { \
+		mkdir -p bin; \
+		archive="chainsaw_$(CHAINSAW_OS)_$(CHAINSAW_ARCH).tar.gz"; \
+		base="https://github.com/kyverno/chainsaw/releases/download/v$(CHAINSAW_VERSION)"; \
+		curl -sSLo "bin/$$archive" "$$base/$$archive"; \
+		curl -sSLo bin/chainsaw-checksums.txt "$$base/checksums.txt"; \
+		(cd bin && grep -E "  $$archive$$" chainsaw-checksums.txt | shasum -a 256 --check); \
+		tar -xzf "bin/$$archive" -C bin chainsaw; \
+		rm -f "bin/$$archive" bin/chainsaw-checksums.txt; \
+	}
+
+.PHONY: e2e-cluster
+e2e-cluster: ## Create the kind cluster used by the e2e tests.
+	kind create cluster --name $(KIND_CLUSTER) --config tests/e2e/kind-config.yaml
+
+.PHONY: e2e-deploy
+e2e-deploy: docker-build ## Build the image, load it into kind and install the chart.
+	kind load docker-image $(IMG) --name $(KIND_CLUSTER)
+	helm upgrade --install crashloop-operator charts/crashloop-operator \
+		--namespace $(NAMESPACE) --create-namespace \
+		--set image.repository=$(firstword $(subst :, ,$(IMG))) \
+		--set image.tag=$(lastword $(subst :, ,$(IMG))) \
+		--set image.pullPolicy=Never \
+		--wait
+
+.PHONY: e2e-run
+e2e-run: chainsaw ## Run the chainsaw e2e tests against the current cluster.
+	bin/chainsaw test tests/e2e --config tests/e2e/chainsaw-config.yaml
+
+.PHONY: e2e
+e2e: e2e-deploy e2e-run ## Deploy into the current cluster and run the e2e tests.
+
+.PHONY: e2e-clean
+e2e-clean: ## Delete the kind cluster.
+	kind delete cluster --name $(KIND_CLUSTER)
 
 .PHONY: ci
 ci: lint vet check-coverage check-manifests vulncheck helm-lint helm-unittest ## Run all CI checks locally.

--- a/api/v1alpha1/crashlooppolicy_envtest_test.go
+++ b/api/v1alpha1/crashlooppolicy_envtest_test.go
@@ -1,0 +1,264 @@
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func newPolicy(name string) *CrashLoopPolicy {
+	return &CrashLoopPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+}
+
+// TestCRDIsClusterScoped guards the fix from the scope change: a namespace on
+// the object must be rejected rather than silently accepted.
+func TestCRDIsClusterScoped(t *testing.T) {
+	ctx := context.Background()
+	p := newPolicy("scope-test")
+	if err := k8sClient.Create(ctx, p); err != nil {
+		t.Fatalf("failed to create cluster-scoped policy: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, p) })
+
+	if p.Namespace != "" {
+		t.Errorf("expected no namespace on a cluster-scoped object, got %q", p.Namespace)
+	}
+}
+
+// TestDefaultingAppliesSpecDefaults verifies the kubebuilder defaults are
+// actually applied by the API server, which the fake client never does.
+func TestDefaultingAppliesSpecDefaults(t *testing.T) {
+	ctx := context.Background()
+	p := newPolicy("defaults-test")
+	if err := k8sClient.Create(ctx, p); err != nil {
+		t.Fatalf("failed to create policy: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, p) })
+
+	if got := p.Spec.RestartThreshold; got != 10 {
+		t.Errorf("expected restartThreshold 10, got %d", got)
+	}
+	if got := p.Spec.DurationThreshold; got != "30m" {
+		t.Errorf("expected durationThreshold 30m, got %q", got)
+	}
+	if got := p.Spec.ReconcileInterval; got != "60s" {
+		t.Errorf("expected reconcileInterval 60s, got %q", got)
+	}
+	if p.Spec.AllReplicasFailing == nil || !*p.Spec.AllReplicasFailing {
+		t.Error("expected allReplicasFailing to default to true")
+	}
+	if p.Spec.DryRun == nil || *p.Spec.DryRun {
+		t.Error("expected dryRun to default to false")
+	}
+	if len(p.Spec.Targets) != 3 {
+		t.Errorf("expected 3 default targets, got %v", p.Spec.Targets)
+	}
+	if len(p.Spec.WatchReasons) != 6 {
+		t.Errorf("expected 6 default watch reasons, got %v", p.Spec.WatchReasons)
+	}
+	if len(p.Spec.ExcludeNamespaces) != 3 {
+		t.Errorf("expected 3 default excluded namespaces, got %v", p.Spec.ExcludeNamespaces)
+	}
+}
+
+// TestExplicitFalseSurvivesRoundTrip is the API-server-side proof for the
+// pointer change: an explicit false must come back as false, not as the
+// default true.
+func TestExplicitFalseSurvivesRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	no := false
+	p := newPolicy("explicit-false-test")
+	p.Spec.AllReplicasFailing = &no
+
+	if err := k8sClient.Create(ctx, p); err != nil {
+		t.Fatalf("failed to create policy: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, p) })
+
+	fetched := &CrashLoopPolicy{}
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: "explicit-false-test"}, fetched); err != nil {
+		t.Fatalf("failed to get policy: %v", err)
+	}
+	if fetched.Spec.AllReplicasFailing == nil {
+		t.Fatal("expected allReplicasFailing to be set, got nil")
+	}
+	if *fetched.Spec.AllReplicasFailing {
+		t.Error("expected an explicit false to survive, got true")
+	}
+}
+
+func TestDurationValidation(t *testing.T) {
+	ctx := context.Background()
+
+	valid := []string{"30m", "60s", "1h30m", "0.5h", "500ms"}
+	for _, v := range valid {
+		p := newPolicy("duration-valid-" + sanitize(v))
+		p.Spec.DurationThreshold = v
+		if err := k8sClient.Create(ctx, p); err != nil {
+			t.Errorf("expected durationThreshold %q to be accepted, got %v", v, err)
+			continue
+		}
+		_ = k8sClient.Delete(ctx, p)
+	}
+
+	invalid := []string{"2 hours", "30", "abc", "-5m", "1d"}
+	for _, v := range invalid {
+		p := newPolicy("duration-invalid-" + sanitize(v))
+		p.Spec.DurationThreshold = v
+		if err := k8sClient.Create(ctx, p); err == nil {
+			t.Errorf("expected durationThreshold %q to be rejected", v)
+			_ = k8sClient.Delete(ctx, p)
+		}
+	}
+}
+
+func TestReconcileIntervalValidation(t *testing.T) {
+	ctx := context.Background()
+
+	p := newPolicy("interval-invalid")
+	p.Spec.ReconcileInterval = "5 minutes"
+	if err := k8sClient.Create(ctx, p); err == nil {
+		t.Error("expected an invalid reconcileInterval to be rejected")
+		_ = k8sClient.Delete(ctx, p)
+	}
+}
+
+func TestRestartThresholdMinimum(t *testing.T) {
+	ctx := context.Background()
+
+	p := newPolicy("restart-zero")
+	p.Spec.RestartThreshold = -1
+	if err := k8sClient.Create(ctx, p); err == nil {
+		t.Error("expected a negative restartThreshold to be rejected")
+		_ = k8sClient.Delete(ctx, p)
+	}
+}
+
+func TestTargetsEnumValidation(t *testing.T) {
+	ctx := context.Background()
+
+	p := newPolicy("targets-invalid")
+	p.Spec.Targets = []string{"Deployment", "DaemonSet"}
+	if err := k8sClient.Create(ctx, p); err == nil {
+		t.Error("expected an unsupported target kind to be rejected")
+		_ = k8sClient.Delete(ctx, p)
+	}
+
+	ok := newPolicy("targets-valid")
+	ok.Spec.Targets = []string{"Deployment", "StatefulSet", "CronJob"}
+	if err := k8sClient.Create(ctx, ok); err != nil {
+		t.Errorf("expected the supported target kinds to be accepted, got %v", err)
+		return
+	}
+	_ = k8sClient.Delete(ctx, ok)
+}
+
+// TestStatusSubresource verifies that status is a real subresource: a plain
+// update must not persist status, and conditions must round-trip.
+func TestStatusSubresource(t *testing.T) {
+	ctx := context.Background()
+	p := newPolicy("status-test")
+	if err := k8sClient.Create(ctx, p); err != nil {
+		t.Fatalf("failed to create policy: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, p) })
+
+	// A normal update must not carry status through.
+	p.Status.Phase = CrashLoopPolicyPhaseActive
+	if err := k8sClient.Update(ctx, p); err != nil {
+		t.Fatalf("failed to update policy: %v", err)
+	}
+	fetched := &CrashLoopPolicy{}
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: "status-test"}, fetched); err != nil {
+		t.Fatalf("failed to get policy: %v", err)
+	}
+	if fetched.Status.Phase != "" {
+		t.Errorf("expected a plain update to leave status empty, got %q", fetched.Status.Phase)
+	}
+
+	// Writing through the status subresource must persist.
+	fetched.Status.Phase = CrashLoopPolicyPhaseActive
+	fetched.Status.ObservedGeneration = fetched.Generation
+	fetched.Status.Conditions = []metav1.Condition{{
+		Type:               "Ready",
+		Status:             metav1.ConditionTrue,
+		Reason:             "ReconcileSucceeded",
+		Message:            "ok",
+		LastTransitionTime: metav1.Now(),
+		ObservedGeneration: fetched.Generation,
+	}}
+	fetched.Status.ActiveScaledDown = []ScaledDownWorkloadRef{{
+		Kind: "Deployment", Namespace: "default", Name: "my-app",
+	}}
+	if err := k8sClient.Status().Update(ctx, fetched); err != nil {
+		t.Fatalf("failed to update status: %v", err)
+	}
+
+	again := &CrashLoopPolicy{}
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: "status-test"}, again); err != nil {
+		t.Fatalf("failed to get policy: %v", err)
+	}
+	if again.Status.Phase != CrashLoopPolicyPhaseActive {
+		t.Errorf("expected phase Active, got %q", again.Status.Phase)
+	}
+	if len(again.Status.Conditions) != 1 {
+		t.Errorf("expected 1 condition, got %d", len(again.Status.Conditions))
+	}
+	if len(again.Status.ActiveScaledDown) != 1 || again.Status.ActiveScaledDown[0].Name != "my-app" {
+		t.Errorf("expected the structured workload ref to round-trip, got %+v", again.Status.ActiveScaledDown)
+	}
+}
+
+// TestConditionsMergeByType covers the list-map markers: two conditions with
+// distinct types coexist, and re-applying one type replaces rather than
+// duplicates it.
+func TestConditionsMergeByType(t *testing.T) {
+	ctx := context.Background()
+	p := newPolicy("conditions-test")
+	if err := k8sClient.Create(ctx, p); err != nil {
+		t.Fatalf("failed to create policy: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, p) })
+
+	p.Status.Conditions = []metav1.Condition{
+		{Type: "Ready", Status: metav1.ConditionTrue, Reason: "A", LastTransitionTime: metav1.Now()},
+		{Type: "Degraded", Status: metav1.ConditionFalse, Reason: "B", LastTransitionTime: metav1.Now()},
+	}
+	if err := k8sClient.Status().Update(ctx, p); err != nil {
+		t.Fatalf("failed to update status: %v", err)
+	}
+
+	fetched := &CrashLoopPolicy{}
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: "conditions-test"}, fetched); err != nil {
+		t.Fatalf("failed to get policy: %v", err)
+	}
+	if len(fetched.Status.Conditions) != 2 {
+		t.Fatalf("expected 2 conditions, got %d", len(fetched.Status.Conditions))
+	}
+
+	// A duplicate type must be rejected by the list-map constraint.
+	fetched.Status.Conditions = append(fetched.Status.Conditions, metav1.Condition{
+		Type: "Ready", Status: metav1.ConditionFalse, Reason: "C", LastTransitionTime: metav1.Now(),
+	})
+	if err := k8sClient.Status().Update(ctx, fetched); err == nil {
+		t.Error("expected a duplicate condition type to be rejected by the list-map constraint")
+	}
+}
+
+// sanitize turns a duration string into something usable as an object name.
+func sanitize(s string) string {
+	out := make([]rune, 0, len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			out = append(out, r)
+		default:
+			out = append(out, '-')
+		}
+	}
+	return string(out)
+}

--- a/api/v1alpha1/suite_test.go
+++ b/api/v1alpha1/suite_test.go
@@ -1,0 +1,60 @@
+package v1alpha1
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+// These tests run against a real API server so that the CRD schema itself is
+// under test: defaulting, pattern and enum validation, and the status
+// subresource. The fake client used by the controller tests applies none of
+// that, so without this suite the kubebuilder markers are unverified.
+
+var (
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+)
+
+func TestMain(m *testing.M) {
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	cfg, err := testEnv.Start()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to start envtest: %v\n", err)
+		fmt.Fprintf(os.Stderr, "hint: install the binaries with 'make envtest-assets'\n")
+		os.Exit(1)
+	}
+
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build scheme: %v\n", err)
+		os.Exit(1)
+	}
+	if err := AddToScheme(s); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to add crashloop types to scheme: %v\n", err)
+		os.Exit(1)
+	}
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: s})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create client: %v\n", err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+
+	if err := testEnv.Stop(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to stop envtest: %v\n", err)
+	}
+	os.Exit(code)
+}

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.0 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
+	github.com/spf13/afero v1.12.0 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
@@ -77,6 +78,7 @@ require (
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260721132016-d427ff9ee9ad // indirect
 	k8s.io/utils v0.0.0-20260626114624-be93311217bd // indirect
+	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.25.0 // indirect
 	sigs.k8s.io/controller-tools v0.22.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
@@ -86,5 +88,6 @@ require (
 
 tool (
 	golang.org/x/vuln/cmd/govulncheck
+	sigs.k8s.io/controller-runtime/tools/setup-envtest
 	sigs.k8s.io/controller-tools/cmd/controller-gen
 )

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,8 @@ github.com/prometheus/common v0.70.0/go.mod h1:S/SFasQmgGiYH6C81LKCtYa8QACgthGg5
 github.com/prometheus/procfs v0.21.1 h1:GljZCt+zSTS+NZq88cyQ1LjZ+RCHp3uVuabBWA5+OJI=
 github.com/prometheus/procfs v0.21.1/go.mod h1:aB55Cww9pdSJVHk0hUf0inxWyyjPogFIjmHKYgMKmtY=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/afero v1.12.0 h1:UcOPyRBYczmFn6yvphxkn9ZEOY65cpwGKb5mL36mrqs=
+github.com/spf13/afero v1.12.0/go.mod h1:ZTlWwG4/ahT8W7T0WQ5uYmjI9duaLQGy3Q2OAl4sk/4=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
@@ -252,6 +254,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.36.0 h1:/YpDJ4vReG7Zm
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.36.0/go.mod h1:tJo1aepTXyR+8Xs3sUsGBDk4Ub2AM5dPAPKJx0mpm5c=
 sigs.k8s.io/controller-runtime v0.25.0 h1:44KgRUPew331KSJpNu8zJow3iTR5W0p/SfrHdw3lV40=
 sigs.k8s.io/controller-runtime v0.25.0/go.mod h1:4QqLdT6z/L6Olj8JJCtvztid4/fnIiYsfaTFScegctc=
+sigs.k8s.io/controller-runtime/tools/setup-envtest v0.25.0 h1:P/fGuSapw13MrCE45zaTc3aC3BQbkk66u7slHxApd1k=
+sigs.k8s.io/controller-runtime/tools/setup-envtest v0.25.0/go.mod h1:q4i4kLTq6J6o29RUAQieHH8LS5knNkpgalnBhvrLp/8=
 sigs.k8s.io/controller-tools v0.22.0 h1:eG3FAVja/KnlXKIWg95udIFz1cMyAtMjP11cqBh3t+k=
 sigs.k8s.io/controller-tools v0.22.0/go.mod h1:VizwUStoZK7rReCj704czGGrB7mLxXTiJSJt7wN5ilI=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=

--- a/go.sum
+++ b/go.sum
@@ -212,6 +212,7 @@ golang.org/x/vuln v1.7.0 h1:4MQBuhmXbz2uepNJrf3v+aaZLGDqw1JluwYboegA1qg=
 golang.org/x/vuln v1.7.0/go.mod h1:Xw7zvU3e1bsCYYBXu+w4wcn2Kgn27f34WBCTw8LL5Us=
 gomodules.xyz/jsonpatch/v2 v2.4.0 h1:Ci3iUJyx9UeRx7CeFN8ARgGbkESwJK+KB9lLcWxY/Zw=
 gomodules.xyz/jsonpatch/v2 v2.4.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
+google.golang.org/genproto v0.0.0-20241118233622-e639e219e697 h1:ToEetK57OidYuqD4Q5w+vfEnPvPpuTwedCNVohYJfNk=
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:Kjn0N0tCrDgiAFW+lGO4JZ3ck44CehvJQMAwj9QF0G8=
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=

--- a/tests/e2e/chainsaw-config.yaml
+++ b/tests/e2e/chainsaw-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Configuration
+metadata:
+  name: crashloop-operator
+spec:
+  parallel: 1
+  timeouts:
+    apply: 1m
+    assert: 5m
+    cleanup: 2m
+    delete: 2m
+    error: 1m

--- a/tests/e2e/kind-config.yaml
+++ b/tests/e2e/kind-config.yaml
@@ -1,0 +1,4 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane

--- a/tests/e2e/scale-down-deployment/chainsaw-test.yaml
+++ b/tests/e2e/scale-down-deployment/chainsaw-test.yaml
@@ -1,0 +1,126 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: scale-down-deployment
+spec:
+  description: >
+    A Deployment whose pods never start must be scaled to zero and annotated
+    with the reason, the previous replica count and the owning policy.
+  steps:
+    - name: create a policy that acts quickly
+      try:
+        - apply:
+            resource:
+              apiVersion: crashloop-operator.lauger.de/v1alpha1
+              kind: CrashLoopPolicy
+              metadata:
+                name: e2e-policy
+              spec:
+                # The image below never pulls, so one restart is never reached.
+                # Act on the duration instead, and do not wait 30 minutes.
+                restartThreshold: 1
+                durationThreshold: 5s
+                reconcileInterval: 5s
+                allReplicasFailing: true
+                targets:
+                  - Deployment
+                excludeNamespaces:
+                  - kube-system
+                  - kube-public
+                  - kube-node-lease
+                  - crashloop-system
+
+    - name: deploy a workload that cannot start
+      try:
+        - apply:
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: broken
+              spec:
+                replicas: 2
+                selector:
+                  matchLabels:
+                    app: broken
+                template:
+                  metadata:
+                    labels:
+                      app: broken
+                  spec:
+                    containers:
+                      - name: app
+                        image: registry.invalid/does-not-exist:v0
+        # No assertion on the pod's exact waiting reason here: it flips between
+        # ErrImagePull and ImagePullBackOff, and asserting on the transient
+        # value only adds flakiness. The scale-down assertion below is the real
+        # outcome, and it cannot pass unless the pods did reach a failing state.
+
+    - name: the operator scales it down and records why
+      try:
+        - assert:
+            timeout: 3m
+            resource:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: broken
+                annotations:
+                  crashloop-operator.lauger.de/previous-replicas: "2"
+                  crashloop-operator.lauger.de/scaled-down-by: e2e-policy
+              spec:
+                replicas: 0
+      catch:
+        - describe:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: broken
+        - describe:
+            apiVersion: v1
+            kind: Pod
+            selector: app=broken
+        - podLogs:
+            namespace: crashloop-system
+            selector: app.kubernetes.io/name=crashloop-operator
+            tail: 100
+        - script:
+            content: |
+              # A pod pulling from an unreachable registry reports ErrImagePull
+              # before settling on ImagePullBackOff, and the operator may act on
+              # either, so accept both rather than racing the transition.
+              kubectl get deployment broken -n $NAMESPACE \
+                -o jsonpath='{.metadata.annotations.crashloop-operator\.lauger\.de/scaled-down-reason}' \
+                | grep -Eq 'ImagePullBackOff|ErrImagePull'
+
+    - name: the policy reports the workload it owns
+      try:
+        - assert:
+            timeout: 2m
+            resource:
+              apiVersion: crashloop-operator.lauger.de/v1alpha1
+              kind: CrashLoopPolicy
+              metadata:
+                name: e2e-policy
+              status:
+                phase: Active
+                conditions:
+                  - type: Ready
+                    status: "True"
+                  - type: Degraded
+                    status: "True"
+      catch:
+        - describe:
+            apiVersion: crashloop-operator.lauger.de/v1alpha1
+            kind: CrashLoopPolicy
+        - podLogs:
+            namespace: crashloop-system
+            selector: app.kubernetes.io/name=crashloop-operator
+            tail: 50
+
+    - name: remove the cluster-scoped policy
+      try:
+        - delete:
+            ref:
+              apiVersion: crashloop-operator.lauger.de/v1alpha1
+              kind: CrashLoopPolicy
+              name: e2e-policy


### PR DESCRIPTION
## Summary

Controller tests all used the fake client, which applies no defaulting, no schema validation and no status subresource semantics. Every kubebuilder marker added across #18, #19 and #4 was therefore unverified: the duration `Pattern`, for instance, was only tested against my own Go regex, never against an API server.

**envtest suite** (`api/v1alpha1`) covering:

- the CRD really is cluster-scoped
- spec defaulting for all seven defaulted fields
- an explicit `allReplicasFailing: false` surviving a round trip, which is the exact regression the pointer change in #19 fixed
- the duration patterns accepting `30m`, `1h30m`, `0.5h`, `500ms` and rejecting `2 hours`, `30`, `abc`, `-5m`, `1d`
- the targets enum and the restartThreshold minimum
- status being a genuine subresource: a plain update must not persist status
- the list-map markers on conditions rejecting a duplicate condition type

**chainsaw e2e** installing the chart into kind, creating a Deployment that cannot pull its image, and asserting the operator scales it to zero with the reason, previous replica count and `scaled-down-by` annotations, then that the policy reports `Active` with `Degraded=True`. A new workflow runs it on pull requests, with operator logs dumped on failure.

**Verification caveat, stated plainly:** I could not run the e2e locally. kind on this machine pulls an amd64 node image and the emulated kubeadm bootstrap times out, which is a limitation of the local Docker setup rather than of the test. The chainsaw files lint clean, and the workflow runs on this PR, so CI on native amd64 is what actually proves the e2e path. Please look at the E2E check before merging.

Two tooling notes. `setup-envtest` joins the `tool` directive next to controller-gen, so `make test` provisions its own control plane binaries. Chainsaw is fetched as a checksum-verified release rather than built from source, because v0.2.14 fails to compile against Go 1.27 (`testing.testDeps` gained a method).

I also dropped an intermediate assertion on the pod's exact waiting reason. It flips between `ErrImagePull` and `ImagePullBackOff`, so asserting on it only adds flakiness, and the scale-down assertion cannot pass unless the pods did reach a failing state anyway.

Closes #30

## Test plan

- `make ci` passes locally end to end with envtest wired in; coverage 60.5 percent.
- All nine envtest cases pass against a real API server locally.
- `chainsaw lint` accepts the test and config files.
- The E2E workflow on this PR is the real check for the kind path.