### PR TITLE
feat(ci): sign the Helm chart and attest the manifest index

### DIFF
--- a/.github/workflows/_container-build.yaml
+++ b/.github/workflows/_container-build.yaml
@@ -155,6 +155,10 @@ jobs:
     permissions:
       packages: write
       id-token: write
+      # Required by actions/attest-build-provenance, which was already
+      # granted at the workflow level but never actually invoked.
+      attestations: write
+      contents: read
     steps:
       - name: Login to ghcr.io
         uses: docker/login-action@v4
@@ -188,13 +192,49 @@ jobs:
             docker buildx imagetools create -t "${IMAGE}:latest" ${SOURCES}
           fi
 
-      - name: Sign image with cosign (keyless)
-        if: inputs.sign
+      - name: Resolve manifest digests
+        id: digests
         run: |
           IMAGE="ghcr.io/${{ github.repository_owner }}/${{ inputs.image_name }}"
           VERSION="${{ needs.prepare.outputs.version }}"
-          DIGEST=$(docker buildx imagetools inspect "${IMAGE}:${VERSION}" --format '{{json .Manifest}}' | jq -r '.digest')
-          cosign sign --yes "${IMAGE}@${DIGEST}"
+
+          digest_of() {
+            docker buildx imagetools inspect "$1" --format '{{json .Manifest}}' | jq -r '.digest'
+          }
+
+          VERSION_DIGEST=$(digest_of "${IMAGE}:${VERSION}")
+          DIGESTS="${VERSION_DIGEST}"
+
+          # :latest is built from the same per-arch sources, so it normally
+          # resolves to the identical index digest and one signature covers
+          # both tags. Compare rather than assume, and sign both if they ever
+          # diverge.
+          if [[ "${{ inputs.latest }}" == "true" ]]; then
+            LATEST_DIGEST=$(digest_of "${IMAGE}:latest")
+            if [[ "${LATEST_DIGEST}" != "${VERSION_DIGEST}" ]]; then
+              echo "::warning::latest and ${VERSION} resolved to different digests, signing both"
+              DIGESTS="${DIGESTS} ${LATEST_DIGEST}"
+            fi
+          fi
+
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "version-digest=${VERSION_DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "all=${DIGESTS}" >> "$GITHUB_OUTPUT"
+
+      - name: Sign image with cosign (keyless)
+        if: inputs.sign
+        run: |
+          for DIGEST in ${{ steps.digests.outputs.all }}; do
+            cosign sign --yes "${{ steps.digests.outputs.image }}@${DIGEST}"
+          done
+
+      - name: Attest build provenance
+        if: inputs.sign
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ${{ steps.digests.outputs.image }}
+          subject-digest: ${{ steps.digests.outputs.version-digest }}
+          push-to-registry: true
 
       - name: Set output
         id: result

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,6 +67,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
+      # Keyless cosign signing exchanges this OIDC token for a Fulcio
+      # certificate, so no private key has to be managed.
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -74,8 +77,13 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v5
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4.1.2
+
       - name: Login to ghcr.io
-        run: echo "${{ github.token }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+        run: |
+          echo "${{ github.token }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+          echo "${{ github.token }}" | cosign login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Inject version into Chart.yaml
         run: |
@@ -84,9 +92,23 @@ jobs:
           sed -i "s/^appVersion:.*/appVersion: \"${VERSION}\"/" charts/crashloop-operator/Chart.yaml
 
       - name: Package and push chart
+        id: push-chart
         run: |
           helm package charts/crashloop-operator
-          helm push crashloop-operator-*.tgz oci://ghcr.io/${{ github.repository_owner }}/charts
+          OUTPUT=$(helm push crashloop-operator-*.tgz \
+            oci://ghcr.io/${{ github.repository_owner }}/charts 2>&1)
+          echo "${OUTPUT}"
+          DIGEST=$(echo "${OUTPUT}" | grep -oP 'sha256:[a-f0-9]+')
+          if [ -z "${DIGEST}" ]; then
+            echo "::error::could not determine the pushed chart digest, refusing to continue unsigned"
+            exit 1
+          fi
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Sign chart with cosign (keyless)
+        run: |
+          cosign sign --yes \
+            "ghcr.io/${{ github.repository_owner }}/charts/crashloop-operator@${{ steps.push-chart.outputs.digest }}"
 
       - name: Upload chart artifact
         uses: actions/upload-artifact@v7
@@ -112,4 +134,4 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           VERSION="${{ needs.semantic-release.outputs.new-release-version }}"
-          gh release upload "v${VERSION}" *.tgz
+          gh release upload "v${VERSION}" ./*.tgz

--- a/README.md
+++ b/README.md
@@ -191,18 +191,44 @@ make docker-build         # Build container image
 
 ## Supply Chain Security
 
-All container images are:
+Released container images **and** Helm charts are:
 
-- **Signed** with [cosign](https://docs.sigstore.dev/cosign/) keyless signing (Sigstore OIDC)
-- **Attested** with [SLSA provenance](https://slsa.dev/) via `docker/build-push-action`
-- **SBOM** generated and attached to each image
+- **Signed** with [cosign](https://docs.sigstore.dev/cosign/) keyless signing (Sigstore OIDC), so there are no private keys to manage or rotate
+- **Attested** with [SLSA provenance](https://slsa.dev/), both the buildkit attestation on each architecture and a registry-attached attestation on the multi-arch index
+- **Accompanied by an SBOM** generated during the build
 
-Verify image signatures:
+Signatures are made against the image digest, so the `:latest` tag and the
+matching version tag are covered by the same signature.
+
+Verify the image:
 
 ```bash
 cosign verify ghcr.io/slauger/crashloop-operator:latest \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate-identity-regexp 'github\.com/slauger/crashloop-operator'
+```
+
+Verify the Helm chart:
+
+```bash
+cosign verify ghcr.io/slauger/charts/crashloop-operator:<version> \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp 'github\.com/slauger/crashloop-operator'
+```
+
+Inspect the provenance attestation:
+
+```bash
+cosign verify-attestation ghcr.io/slauger/crashloop-operator:latest \
+  --type slsaprovenance \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp 'github\.com/slauger/crashloop-operator'
+```
+
+List everything attached to an image:
+
+```bash
+cosign tree ghcr.io/slauger/crashloop-operator:latest
 ```
 
 ## License


### PR DESCRIPTION
## Summary

- **The chart is now signed.** The image was cosign-signed but the released chart was not, so users could verify what they ran but not what they installed. The release job captures the digest from `helm push` and signs it keylessly. If the digest cannot be parsed the job fails rather than publishing an unsigned chart.
- **Provenance is actually attested.** `attestations: write` was granted in the container build but `actions/attest-build-provenance` was never called, so the fused multi-arch index had no registry-attached attestation. It is now invoked against the index digest with `push-to-registry`.
- **README** documents verification for the image, the chart, the provenance attestation, and `cosign tree`.

**On the issue's third bullet, signing `:latest` separately.** That turned out not to be a real gap. `:latest` is created by `imagetools create` from the same per-arch sources, so it resolves to the identical index digest, and cosign signs by digest rather than by tag: one signature already covers both. Rather than add a redundant call or just assert this in a comment, the workflow now resolves both digests, compares them, and signs both if they ever diverge, with a warning. That is correct either way and documents the reasoning in code.

I left the optional `_cleanup-images.yaml` port out. Registry hygiene is unrelated to signing, and bundling a workflow that deletes ghcr package versions into a supply-chain PR makes both harder to review.

The Artifact Hub OCI metadata push that sits next to chart signing in openvox-operator belongs to #25 and is not included here.

Closes #23

## Test plan

- `make ci` passes locally.
- `actionlint` reports no findings on `release.yaml` and none on the steps added to `_container-build.yaml`. I also fixed the one pre-existing `SC2035` nit in the release-assets job while in the file.
- Note this code path only executes during a real release, which is manually dispatched and owned by you, so CI on this PR exercises the workflow syntax rather than the signing itself. The chart-signing steps are a direct port of what openvox-operator already runs in production.