### PR TITLE
feat(ci): validate released images with Conforma

### DIFF
--- a/.conforma/policy.yaml
+++ b/.conforma/policy.yaml
@@ -1,0 +1,16 @@
+sources:
+  - name: supply-chain-security
+    policy:
+      # renovate: datasource=github-releases depName=conforma/policy
+      - github.com/conforma/policy//policy/lib?ref=v1.0.28
+      - github.com/conforma/policy//policy/release?ref=v1.0.28
+    config:
+      include:
+        - '@github'
+    ruleData:
+      # The runtime stage runs on ubi9-minimal and the builder stage on the
+      # official Go image, so both registries have to be allowed or the base
+      # image rule reports a violation for a base image we chose deliberately.
+      allowed_registry_prefixes:
+        - "registry.access.redhat.com/"
+        - "docker.io/library/"

--- a/.github/workflows/_conforma-validate.yaml
+++ b/.github/workflows/_conforma-validate.yaml
@@ -1,0 +1,71 @@
+name: Conforma Validate
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: "Full image reference (registry/owner/name:tag)"
+        required: true
+        type: string
+      digest:
+        description: "Image manifest digest (sha256:...). If empty, the tag in image is resolved by ec."
+        required: false
+        type: string
+        default: ""
+      strict:
+        description: "Fail the job on policy violations"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: read
+    env:
+      # renovate: datasource=github-releases depName=conforma/cli
+      EC_VERSION: "0.10.3"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install ec CLI
+        run: |
+          cd /tmp
+          curl -sSLO "https://github.com/conforma/cli/releases/download/v${EC_VERSION}/ec_linux_amd64"
+          curl -sSLO "https://github.com/conforma/cli/releases/download/v${EC_VERSION}/ec_linux_amd64.sha256"
+          # The published checksum file refers to dist/ec_linux_amd64.
+          sed -i 's|dist/||' ec_linux_amd64.sha256
+          sha256sum --check ec_linux_amd64.sha256
+          chmod +x ec_linux_amd64
+          sudo mv ec_linux_amd64 /usr/local/bin/ec
+
+      - name: Login to ghcr.io
+        run: echo "${{ github.token }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Validate image with Conforma
+        run: |
+          IMAGE_REF="${{ inputs.image }}"
+          if [[ -n "${{ inputs.digest }}" ]]; then
+            IMAGE_REF="${{ inputs.image }}@${{ inputs.digest }}"
+          fi
+
+          ARGS=(
+            validate image
+            --image "${IMAGE_REF}"
+            --policy .conforma/policy.yaml
+            --certificate-identity-regexp "https://github.com/${{ github.repository }}/"
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+            --show-successes
+            --output yaml
+          )
+          if [[ "${{ inputs.strict }}" == "true" ]]; then
+            ARGS+=(--strict)
+          else
+            ARGS+=(--strict=false)
+          fi
+
+          ec "${ARGS[@]}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,6 +61,21 @@ jobs:
       latest: true
       image_tag: ${{ needs.semantic-release.outputs.new-release-version }}
 
+  validate-crashloop-operator:
+    needs: [semantic-release, crashloop-operator]
+    if: needs.semantic-release.outputs.new-release-published == 'true'
+    uses: ./.github/workflows/_conforma-validate.yaml
+    permissions:
+      contents: read
+      id-token: write
+      packages: read
+    with:
+      image: ${{ needs.crashloop-operator.outputs.image }}
+      # Reporting only for now. Flip to true once a release has gone through
+      # and the policy output has been reviewed, so that a first run cannot
+      # block a release on a rule nobody has looked at yet.
+      strict: false
+
   helm-charts:
     needs: [semantic-release, crashloop-operator]
     if: needs.semantic-release.outputs.new-release-published == 'true'

--- a/README.md
+++ b/README.md
@@ -225,6 +225,20 @@ cosign verify-attestation ghcr.io/slauger/crashloop-operator:latest \
   --certificate-identity-regexp 'github\.com/slauger/crashloop-operator'
 ```
 
+Released images are additionally validated against a
+[Conforma](https://conforma.dev/) policy during the release, which checks the
+signature, the provenance attestation and the base images against the rules in
+`.conforma/policy.yaml`. To run the same check yourself:
+
+```bash
+ec validate image \
+  --image ghcr.io/slauger/crashloop-operator:<version> \
+  --policy .conforma/policy.yaml \
+  --certificate-identity-regexp 'https://github.com/slauger/crashloop-operator/' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --output yaml
+```
+
 List everything attached to an image:
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a reusable Conforma workflow plus `.conforma/policy.yaml`, wired into `release.yaml` after the image build. It verifies the cosign signature, the provenance attestation added in #23, and the base images against the Conforma release policy, so the supply-chain artefacts are actually checked rather than just produced.

Two deliberate deviations from the openvox-operator original:

- **Policy pinned to v1.0.28**, not the v1.0.22 openvox currently uses. There was no reason to adopt a stale pin on a fresh integration; renovate will keep it moving via the annotation.
- **`allowed_registry_prefixes` lists `registry.access.redhat.com/` and `docker.io/library/`.** openvox allows the two Red Hat registries because that matches its images. This project builds on the official Go image and runs on ubi9-minimal, so without the `docker.io/library/` entry the base-image rule would report a violation for a base image we chose on purpose.

It runs in **reporting mode** (`strict: false`). Enabling strict before anyone has read the policy output would risk a first release blocked by a rule nobody has reviewed. Once you have seen one run, flipping the input to `true` is a one-line change.

Closes #35

## Test plan

- Downloaded ec v0.10.3 locally and confirmed the checksum flow the workflow uses works, including the `dist/` prefix the published `.sha256` file carries.
- Verified the policy against the real CLI: `ec inspect policy` parses it and resolves both sources, with `v1.0.28` resolving to a concrete commit, so the pinned ref exists and the rule set loads.
- `actionlint` reports no findings on the new workflow or on `release.yaml`.
- `make ci` passes.
- As with #23, the job itself only executes during a manually dispatched release, so CI here covers syntax and wiring rather than a live validation run.