### PR TITLE
feat(helm): prepare the Artifact Hub listing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -125,6 +125,22 @@ jobs:
           cosign sign --yes \
             "ghcr.io/${{ github.repository_owner }}/charts/crashloop-operator@${{ steps.push-chart.outputs.digest }}"
 
+      - name: Install oras
+        uses: oras-project/setup-oras@v2
+
+      - name: Push Artifact Hub metadata
+        run: |
+          REPOSITORY_ID=$(grep -E '^repositoryID:' artifacthub-repo.yml \
+            | sed -E 's/^repositoryID:[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/')
+          if [ -z "${REPOSITORY_ID}" ]; then
+            echo "::notice::artifacthub-repo.yml has no repositoryID yet, skipping the metadata push"
+            exit 0
+          fi
+          oras push \
+            "ghcr.io/${{ github.repository_owner }}/charts/crashloop-operator:artifacthub.io" \
+            --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
+            artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
+
       - name: Upload chart artifact
         uses: actions/upload-artifact@v7
         with:

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,12 @@
+# Artifact Hub repository metadata. This file is pushed to the chart's OCI
+# repository during a release so that Artifact Hub can verify who owns it.
+#
+# repositoryID is issued by Artifact Hub when the repository is registered as
+# kind OCI with the URL oci://ghcr.io/slauger/charts/crashloop-operator. Until
+# it is filled in the release workflow skips the push, because publishing this
+# file with a blank or wrong ID would fail verification rather than establish
+# it.
+repositoryID: ""
+owners:
+  - name: Simon Lauger
+    email: simon@lauger.de

--- a/assets/icon.svg
+++ b/assets/icon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128" role="img" aria-label="crashloop-operator">
+  <title>crashloop-operator</title>
+  <rect width="128" height="128" rx="24" fill="#1f2933"/>
+  <!-- An interrupted restart loop: the arc is broken at the top, and the
+       arrow points down to represent the workload being scaled to zero. -->
+  <g fill="none" stroke="#7fb3d5" stroke-width="9" stroke-linecap="round">
+    <path d="M 40 34 A 34 34 0 1 0 88 34"/>
+  </g>
+  <g fill="none" stroke="#e8833a" stroke-width="9" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M 64 44 L 64 92"/>
+    <path d="M 48 76 L 64 92 L 80 76"/>
+  </g>
+</svg>

--- a/charts/crashloop-operator/Chart.yaml
+++ b/charts/crashloop-operator/Chart.yaml
@@ -16,3 +16,47 @@ keywords:
   - operator
   - kubernetes
   - scaling
+  - cost-optimization
+icon: https://raw.githubusercontent.com/slauger/crashloop-operator/develop/assets/icon.svg
+# The operator relies on nothing newer than the stable apps and batch APIs,
+# but 1.29 is the oldest release still receiving patches when this was set.
+kubeVersion: ">=1.29.0-0"
+annotations:
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/category: integration-delivery
+  artifacthub.io/operator: "true"
+  # The chart carries no conversion webhook or migration logic, so an upgrade
+  # is a plain image and CRD roll-forward.
+  artifacthub.io/operatorCapabilities: Basic Install
+  artifacthub.io/images: |
+    - name: crashloop-operator
+      image: ghcr.io/slauger/crashloop-operator:latest
+  artifacthub.io/links: |
+    - name: Source Code
+      url: https://github.com/slauger/crashloop-operator
+    - name: Issue Tracker
+      url: https://github.com/slauger/crashloop-operator/issues
+  artifacthub.io/crds: |
+    - kind: CrashLoopPolicy
+      version: v1alpha1
+      name: crashlooppolicies.crashloop-operator.lauger.de
+      displayName: CrashLoop Policy
+      description: Cluster-scoped policy describing which failing workloads to scale down and when
+  artifacthub.io/crdsExamples: |
+    - apiVersion: crashloop-operator.lauger.de/v1alpha1
+      kind: CrashLoopPolicy
+      metadata:
+        name: default
+      spec:
+        restartThreshold: 10
+        durationThreshold: 30m
+        allReplicasFailing: true
+        targets:
+          - Deployment
+          - StatefulSet
+          - CronJob
+        excludeNamespaces:
+          - kube-system
+          - kube-public
+          - kube-node-lease
+        dryRun: false

--- a/charts/crashloop-operator/README.md
+++ b/charts/crashloop-operator/README.md
@@ -67,6 +67,10 @@ policies gone too.
 | ---- | ------ | --- |
 | Simon Lauger | <simon@lauger.de> | <https://lauger.de> |
 
+## Requirements
+
+Kubernetes: `>=1.29.0-0`
+
 ## Values
 
 | Key | Type | Default | Description |


### PR DESCRIPTION
## Summary

Adds everything Artifact Hub renders for a chart: `license`, `category`, the operator flag and capabilities, `images`, `links`, the `CrashLoopPolicy` CRD entry, and a worked `crdsExamples` policy. Plus `kubeVersion` (`>=1.29.0-0`, matching the README prerequisite) and an `icon`, without which the listing shows a blank tile.

`artifacthub-repo.yml` is committed and pushed to the chart's OCI repository during a release via oras, so Artifact Hub can verify ownership.

**The one part I cannot finish.** `repositoryID` is issued by Artifact Hub when you register the repository (kind OCI, URL `oci://ghcr.io/slauger/charts/crashloop-operator`), so it is empty here. Rather than commit a placeholder that would fail verification, the release step reads the ID and skips the push while it is blank, emitting a notice. Filling in the ID is then a one-line edit and the wiring already works. I tested the extraction against both an empty value and a real UUID.

**On `operatorCapabilities`.** openvox-operator declares `Seamless Upgrades`; I used `Basic Install`, because this chart carries no conversion webhook or migration logic, so claiming the higher tier would be inaccurate.

**On the icon.** The project had no artwork, so I drew a minimal mark: an interrupted restart loop with a downward arrow. It is a placeholder in the sense that you may well want something else, and swapping the file is enough. It is referenced from the `develop` branch since `main` does not exist; that URL should move to `main` once you create it.

Closes #25

## Test plan

- `make ci` passes, including the RBAC and docs drift gates, and `helm lint` no longer warns about the missing icon.
- Each embedded annotation block (`crds`, `crdsExamples`, `images`, `links`) was parsed with `yq` to confirm it is valid YAML inside the string, which is the usual way these silently break.
- Cross-checked every field in the `crdsExamples` policy against the generated CRD schema so the published example cannot reference a field that does not exist.
- The SVG was checked for well-formedness.
- `actionlint` reports no findings on the changed release workflow.