### PR TITLE
fix(build): inject build metadata, trim the binary and pin base images

### DIFF
--- a/.github/workflows/_container-build.yaml
+++ b/.github/workflows/_container-build.yaml
@@ -133,6 +133,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
+      # Each architecture builds in its own job, so the stamp is taken per job.
+      # It records when the image was built, which is what
+      # org.opencontainers.image.created means, not the commit date.
+      - name: Determine build date
+        id: build-date
+        run: echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@v7
         with:
@@ -143,6 +150,10 @@ jobs:
           provenance: true
           sbom: true
           tags: ghcr.io/${{ github.repository_owner }}/${{ inputs.image_name }}:${{ needs.prepare.outputs.version }}-${{ steps.platform.outputs.suffix }}
+          build-args: |
+            VERSION=${{ needs.prepare.outputs.version }}
+            COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ steps.build-date.outputs.date }}
           cache-from: type=gha,scope=${{ inputs.image_name }}-${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=${{ inputs.image_name }}-${{ matrix.platform }}
 

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,3 +1,0 @@
-ignored:
-  - DL3008  # apt-get version pinning -- transient build stage, not runtime
-  - DL3041  # dnf version pinning -- versions come from UBI9 repos

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
+	goruntime "runtime"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -15,6 +17,14 @@ import (
 
 	crashloopv1alpha1 "github.com/slauger/crashloop-operator/api/v1alpha1"
 	"github.com/slauger/crashloop-operator/internal/controller"
+)
+
+// Build metadata, injected via -ldflags at build time. The defaults apply to
+// a plain `go build`, which is what a developer running from source gets.
+var (
+	version   = "dev"
+	commit    = "unknown"
+	buildDate = "unknown"
 )
 
 var (
@@ -32,6 +42,7 @@ func main() {
 	var probeAddr string
 	var enableLeaderElection bool
 	var watchNamespace string
+	var showVersion bool
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -40,12 +51,24 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&watchNamespace, "watch-namespace", "",
 		"Namespace to restrict the operator to. If empty, the operator watches all namespaces (cluster-wide).")
+	flag.BoolVar(&showVersion, "version", false, "Print version information and exit.")
 
 	opts := zap.Options{Development: false}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
+	if showVersion {
+		fmt.Printf("crashloop-operator %s (commit %s, built %s, %s)\n",
+			version, commit, buildDate, goruntime.Version())
+		return
+	}
+
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	// Logged once at startup so a running operator can be tied back to the
+	// build it came from without exec-ing into the container.
+	setupLog.Info("starting crashloop-operator",
+		"version", version, "commit", commit, "buildDate", buildDate, "go", goruntime.Version())
 
 	mgrOptions := ctrl.Options{
 		Scheme:                 scheme,

--- a/images/crashloop-operator/Containerfile
+++ b/images/crashloop-operator/Containerfile
@@ -1,22 +1,50 @@
-FROM docker.io/library/golang:1.27.1 AS builder
+FROM docker.io/library/golang:1.27.1@sha256:512690a5660563b57d37ecc31129e7f136e831db2aed24a1dbeb8ad7380dc0fa AS builder
 
 WORKDIR /workspace
+
+# Kept as its own layer rather than a cache mount: the registry layer cache is
+# shared across CI runs, whereas buildkit cache mounts are not exported, so a
+# cache mount here would make every CI build re-download the modules.
 COPY go.mod go.sum ./
 RUN go mod download
+
 COPY cmd/ cmd/
 COPY api/ api/
 COPY internal/ internal/
-ARG TARGETARCH
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -o manager ./cmd/main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1788166357
+ARG TARGETARCH
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
+
+# The compile cache is not captured by the layer cache at all, so a cache mount
+# is a pure win here. -trimpath keeps absolute build paths out of the binary so
+# the same source yields the same output, and -s -w drops the symbol table and
+# DWARF data, which the operator has no use for at runtime.
+RUN --mount=type=cache,target=/root/.cache/go-build,sharing=locked \
+    CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
+    go build -a -trimpath \
+      -ldflags="-s -w \
+        -X main.version=${VERSION} \
+        -X main.commit=${COMMIT} \
+        -X main.buildDate=${BUILD_DATE}" \
+      -o manager ./cmd/main.go
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1788166357@sha256:7fbeae18dc9476399f565e68255f602a3374ea8614ba3d14843565131a13ff93
+
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
 
 LABEL org.opencontainers.image.title="CrashLoop Operator" \
       org.opencontainers.image.description="Kubernetes operator that scales down workloads stuck in CrashLoopBackOff and similar terminal failure states" \
       org.opencontainers.image.vendor="slauger" \
       org.opencontainers.image.url="https://github.com/slauger/crashloop-operator" \
       org.opencontainers.image.source="https://github.com/slauger/crashloop-operator" \
-      org.opencontainers.image.licenses="Apache-2.0"
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${COMMIT}" \
+      org.opencontainers.image.created="${BUILD_DATE}"
 
 COPY --from=builder /workspace/manager /manager
 


### PR DESCRIPTION
## Summary

- **Build metadata.** The binary carried none, so a running operator could not be tied back to the commit it came from. Version, commit and build date are injected via ldflags, exposed through a `--version` flag, logged once at startup, and mirrored into the `org.opencontainers.image.version`/`revision`/`created` labels from workflow build args.
- **`-trimpath` and `-s -w`** so absolute build paths stay out of the binary and the symbol table and DWARF data, which the operator has no use for at runtime, are dropped.
- **Digest-pinned both base images**, keeping the readable tag alongside so renovate still tracks them.
- **Removed `.hadolint.yaml`.** Its two ignores were for apt and dnf version pinning and the Containerfile invokes neither. hadolint is clean with no config at all, so the file was pure noise.

**Cache mounts, partially.** I added one for the Go build cache, which the layer cache does not capture at all, so it is a clear win. I deliberately did *not* convert the module download: buildkit cache mounts are not exported to the GitHub Actions cache backend, so moving `go mod download` off its own layer would make every CI build re-download the modules. That would have been a pessimisation dressed up as an optimisation, so the reasoning is recorded in the Containerfile.

**Base image evaluation, with numbers.** I built both and measured rather than guessing: **UBI9-minimal 140 MB, distroless/static 35.4 MB**, so roughly a 4x difference. That is a real argument for distroless, but the base image is an ecosystem decision rather than a mechanical fix: openvox-operator, the reference this project is being aligned to, uses UBI, and the Conforma policy from #35 currently allows only the Red Hat and docker.io/library prefixes. I stayed on UBI and filed the measurements as a separate issue so you can decide with the data in front of you rather than have it changed under you.

Closes #31

## Test plan

Verified against real builds, not by inspection:

- Built the image with build args and ran it: `--version` prints `crashloop-operator 1.2.3 (commit abc1234, built 2026-09-05T00:00:00Z, go1.27.1)`, and `docker inspect` shows the three OCI labels populated.
- Rebuilt after digest-pinning both stages and confirmed the image still builds and runs.
- `hadolint` passes with the config removed.
- `make ci` passes end to end; coverage 60.0 percent.
- `actionlint` introduces no new findings on the changed workflow.