### PR TITLE
docs: add SECURITY.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,111 @@
+# Contributing
+
+Thanks for your interest in the project. This page covers what you need to get
+a change merged.
+
+## Prerequisites
+
+- Go, at the version in [go.mod](go.mod). The Makefile pulls the tools it needs
+  (controller-gen, govulncheck, setup-envtest) through the `tool` directive, so
+  there is nothing to install by hand.
+- Docker or Podman, for building the image and running the e2e tests.
+- Helm 3.8 or newer.
+- [golangci-lint](https://golangci-lint.run/welcome/install/), the only tool not
+  fetched automatically. CI pins the version in
+  [.github/workflows/_go.yaml](.github/workflows/_go.yaml); match it locally to
+  avoid surprises.
+- kind, only if you want to run the e2e tests.
+
+## Before you push
+
+```bash
+make ci
+```
+
+That runs everything CI runs: linting, `go vet`, tests under the race detector
+with a coverage gate, drift checks, `govulncheck`, chart linting and the chart
+unit tests. Run `make help` for the individual targets.
+
+Two of those checks catch mistakes that are easy to make:
+
+- **`make check-manifests`** fails when generated code is stale. Run
+  `make generate manifests` after touching anything under `api/v1alpha1/` or
+  any `+kubebuilder:` marker, and commit the result.
+- **`make check-helm-docs`** and **`make check-rbac`** fail when the chart
+  README, `values.schema.json` or the chart RBAC no longer match their sources.
+  Run `make helm-docs helm-schema` after editing `values.yaml`, and
+  `make manifests` after changing an RBAC marker.
+
+## Tests
+
+Unit and integration tests run with `make test`.
+
+- Controller tests use the fake client and live in `internal/controller/`. Build
+  fixtures with the helpers in `testutil_test.go` rather than hand-rolling
+  objects.
+- API tests run against a real API server through envtest and live in
+  `api/v1alpha1/`. Anything that depends on defaulting, schema validation or the
+  status subresource belongs there, because the fake client applies none of it.
+- Chart behaviour is covered by helm-unittest under
+  `charts/crashloop-operator/tests/`.
+
+The end-to-end tests use [Chainsaw](https://kyverno.github.io/chainsaw/) against
+a kind cluster:
+
+```bash
+make e2e-cluster   # create the cluster
+make e2e           # build, load, install and run the tests
+make e2e-clean     # tear the cluster down
+```
+
+## Branching
+
+`develop` is the development branch and the target for all pull requests.
+`main` is release-only and is updated by the maintainer.
+
+Branch from `origin/develop` and name the branch after what it does, for
+example `feat/pending-pod-detection` or `fix/status-churn`.
+
+## Commits and pull requests
+
+Commits follow [Conventional Commits](https://www.conventionalcommits.org/),
+because releases and their notes are generated from the history. Use a
+lowercase subject with no trailing period:
+
+```
+feat(controller): detect permanently pending pods
+fix(api): reject a negative restart threshold
+docs: document the multi-policy ordering
+```
+
+While the project is pre-1.0, a breaking change releases as a **minor** version,
+so mark it with `!` or a `BREAKING CHANGE:` footer and say in the body what
+users have to change.
+
+Give the pull request a conventional title, a `## Summary` and a `## Test plan`
+section, and a `Closes #<issue>` line where one applies.
+
+Write commit messages, code comments and documentation in plain ASCII. CI
+rejects typographic quotes, en and em dashes and similar characters.
+
+## Code conventions
+
+- Use `updateStatusWithRetry` or `updatePolicyStatusIfChanged` for status
+  writes. The latter skips the write when nothing changed, which keeps the
+  operator from churning the object on every interval.
+- Read defaulted spec fields through the `effective*` accessors in
+  `internal/controller/policyresolve.go` instead of repeating the fallback.
+- Errors inside the reconcile loop should be counted rather than swallowed, so
+  the `Ready` condition can report a partial failure.
+
+## Documentation
+
+Documentation is part of the change, not a follow-up:
+
+| You changed | Also update |
+|---|---|
+| A CRD field | The spec or status table in [README.md](README.md) and the sample in `config/samples/` |
+| A `+kubebuilder:default` | The table, and any prose that states the default |
+| A chart value | The comment in `values.yaml`, then run `make helm-docs helm-schema` |
+| An RBAC marker | Run `make manifests`; the chart templates may need the matching rule |
+| Operator behaviour | The relevant README section, and `NOTES.txt` if it affects first use |

--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,22 @@ check-manifests: manifests generate ## Check for CRD and deepcopy drift.
 		exit 1; \
 	fi
 
+.PHONY: check-rbac
+check-rbac: manifests ## Check the chart RBAC matches the kubebuilder markers.
+	./hack/check-rbac.sh
+
+.PHONY: check-helm-docs
+check-helm-docs: helm-docs helm-schema ## Check the chart README and schema are up to date.
+	@if ! git diff HEAD --quiet -- charts/crashloop-operator/README.md charts/crashloop-operator/values.schema.json; then \
+		echo "error: chart README or values.schema.json is out of date. Run 'make helm-docs helm-schema' and commit the result."; \
+		git diff HEAD --stat -- charts/crashloop-operator/README.md charts/crashloop-operator/values.schema.json; \
+		exit 1; \
+	fi
+
+.PHONY: ci
+ci: lint vet check-coverage check-manifests vulncheck helm-lint helm-unittest check-helm-docs check-rbac ## Run all CI checks locally.
+	@echo "All CI checks passed."
+
 ##@ E2E
 
 # renovate: datasource=github-releases depName=kyverno/chainsaw
@@ -210,21 +226,6 @@ e2e: e2e-deploy e2e-run ## Deploy into the current cluster and run the e2e tests
 e2e-clean: ## Delete the kind cluster.
 	kind delete cluster --name $(KIND_CLUSTER)
 
-.PHONY: check-rbac
-check-rbac: manifests ## Check the chart RBAC matches the kubebuilder markers.
-	./hack/check-rbac.sh
-
-.PHONY: check-helm-docs
-check-helm-docs: helm-docs helm-schema ## Check the chart README and schema are up to date.
-	@if ! git diff HEAD --quiet -- charts/crashloop-operator/README.md charts/crashloop-operator/values.schema.json; then \
-		echo "error: chart README or values.schema.json is out of date. Run 'make helm-docs helm-schema' and commit the result."; \
-		git diff HEAD --stat -- charts/crashloop-operator/README.md charts/crashloop-operator/values.schema.json; \
-		exit 1; \
-	fi
-
-.PHONY: ci
-ci: lint vet check-coverage check-manifests vulncheck helm-lint helm-unittest check-helm-docs check-rbac ## Run all CI checks locally.
-	@echo "All CI checks passed."
 
 ##@ Help
 

--- a/README.md
+++ b/README.md
@@ -182,12 +182,17 @@ policies are evaluated.
 ## Local Development
 
 ```bash
-make generate manifests   # Regenerate deepcopy + CRD YAML + Helm CRDs
+make generate manifests   # Regenerate deepcopy, CRD YAML, RBAC and chart CRDs
 make build                # Build operator binary
-make test                 # Run unit tests
-make ci                   # Full CI: lint + test + helm-lint + check-manifests
+make test                 # Run unit and envtest tests
+make ci                   # Everything CI runs
+make e2e-cluster && make e2e   # End-to-end tests on kind
 make docker-build         # Build container image
 ```
+
+`make help` lists every target. See [CONTRIBUTING.md](CONTRIBUTING.md) for the
+branching model, commit conventions and the drift checks that catch stale
+generated files.
 
 ## Supply Chain Security
 
@@ -244,6 +249,12 @@ List everything attached to an image:
 ```bash
 cosign tree ghcr.io/slauger/crashloop-operator:latest
 ```
+
+## Security
+
+Please report vulnerabilities privately to simon@lauger.de rather than in a
+public issue. See [SECURITY.md](SECURITY.md), which also describes the
+operator's blast radius and the mechanisms that limit it.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,89 @@
+# Security Policy
+
+## Supported Versions
+
+| Version        | Supported          |
+|----------------|--------------------|
+| Latest release | :white_check_mark: |
+| Older releases | :x:                |
+
+The project is pre-1.0 and under active development. Security fixes go into the
+next release rather than being backported.
+
+## Reporting a Vulnerability
+
+Please report vulnerabilities privately:
+
+1. **Do not** open a public GitHub issue.
+2. Email [simon@lauger.de](mailto:simon@lauger.de) describing the issue.
+3. Include reproduction steps and the affected version if you can.
+
+You should get a response within 7 days. Once confirmed, a fix is developed and
+released as soon as practical.
+
+## Security Considerations
+
+This operator handles no secrets, certificates or credentials. Its security
+relevance is different: **it can take workloads down.**
+
+### Blast radius
+
+The operator sets `replicas` to `0` on Deployments and StatefulSets and
+suspends CronJobs. Anyone who can create or edit a `CrashLoopPolicy` can
+therefore cause an outage, whether by mistake or on purpose.
+
+`CrashLoopPolicy` is deliberately **cluster-scoped** so that creating one is an
+administrative act. Treat write access to it the way you would treat any
+cluster-wide permission, and do not grant it to workload teams by default.
+
+Three mechanisms limit the damage a policy can do:
+
+- `dryRun: true` logs and emits events for the workloads a policy would act on
+  without touching them. Use it whenever a policy is new or has been changed.
+- `excludeNamespaces` defaults to `kube-system`, `kube-public` and
+  `kube-node-lease`, so a default policy will not disable cluster components.
+  Setting the field replaces that default rather than adding to it.
+- `namespaceSelector` and `excludeWorkloadSelector` narrow which namespaces and
+  workloads a policy considers at all.
+
+The operator never scales anything back up. Recovery is deliberately left to
+whatever manages your workloads, so a scale-down cannot be silently undone.
+
+### RBAC
+
+Permissions follow least privilege and are generated from the
+`+kubebuilder:rbac` markers in the controller, with a CI check
+(`make check-rbac`) that fails if the chart grants more or less than the
+markers declare.
+
+The chart splits access in two. Policy, namespace and event access is always a
+ClusterRole, because those are cluster-scoped resources. Workload access
+follows `scope.mode`: `cluster` grants it everywhere, `namespace` confines it to
+a single namespace via a Role, which is the tightest deployment the operator
+supports.
+
+### Container hardening
+
+The operator pod runs with:
+
+- `runAsNonRoot: true`, UID 1001
+- `readOnlyRootFilesystem: true`
+- `allowPrivilegeEscalation: false`
+- all capabilities dropped
+- `seccompProfile: RuntimeDefault`
+
+### Metrics endpoint
+
+The controller-runtime metrics endpoint listens on port 8080 **without
+authentication**. The chart does not expose it: `metrics.service.enabled`
+defaults to `false`, so it is reachable only from inside the pod network to
+whatever can already reach the pod. If you enable the Service, restrict access
+accordingly. The metrics contain no secrets, but they do reveal namespace and
+workload names.
+
+### Supply chain
+
+Released images and Helm charts are signed with cosign using keyless Sigstore
+signing, carry SLSA provenance and an SBOM, and are validated against a
+[Conforma](https://conforma.dev/) policy at release time. Verification commands
+are in the [README](README.md#supply-chain-security).


### PR DESCRIPTION
## Summary

The README claimed supply-chain guarantees while offering no channel to report a vulnerability. That gap is now closed.

**SECURITY.md** is written for what this operator actually is, rather than being a copy of the openvox-operator template. That project's security story is secrets, CA keys and tokens; this one holds none of those. Its security relevance is that **it can take workloads down**, so the document covers:

- the blast radius, and why `CrashLoopPolicy` being cluster-scoped makes creating one an administrative act
- the three mechanisms that limit damage: `dryRun`, the `excludeNamespaces` defaults (noting that setting the field *replaces* rather than extends them, which is easy to get wrong), and the selectors
- that the operator never scales back up, so a scale-down cannot be silently undone
- the RBAC split and the `make check-rbac` gate that keeps it honest
- the pod hardening settings
- **that the metrics endpoint is unauthenticated**, and only unexposed because `metrics.service.enabled` defaults to false. Worth stating explicitly before someone enables the Service.

**CONTRIBUTING.md** covers prerequisites, `make ci`, the develop-first branching model, Conventional Commits including the pre-1.0 rule that breaking changes release as minor, the test layout (fake client vs envtest vs helm-unittest and what belongs where), and a documentation mapping table. It leads with the drift checks, since stale generated files are the most likely reason a first pull request goes red.

**Also fixed `make help`.** The CI targets had drifted into the E2E section as I added things over previous PRs, and `ci` itself was not listed at all, which would have made the first instruction in CONTRIBUTING.md hard to discover.

Closes #27

## Test plan

Every factual claim in both documents was checked against the code rather than assumed:

- both status helpers and all seven `effective*` accessors exist where the text says they do
- the image runs as UID 1001 and the pod security context matches the listed settings
- the metrics endpoint binds `:8080` with no filter provider, and `metrics.service.enabled` is `false`
- `make help` now lists `lint`, `vulncheck`, `check-manifests`, `check-rbac`, `check-helm-docs` and `ci` under CI
- both files are plain ASCII, so the unicode lint passes
- `make ci` passes end to end
