### PR TITLE
chore: adopt the expanded golangci-lint standard

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,12 +6,55 @@ run:
 linters:
   default: standard
   enable:
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - copyloopvar
+    - dogsled
+    - durationcheck
     - errorlint
+    - gocritic
     - gosec
+    - importas
+    - intrange
+    - loggercheck
     - misspell
+    - modernize
+    - nakedret
+    - nilerr
+    - nolintlint
+    - prealloc
     - revive
     - unconvert
+    - unparam
   settings:
+    importas:
+      no-unaliased: true
+      alias:
+        - pkg: k8s.io/api/core/v1
+          alias: corev1
+        - pkg: k8s.io/api/apps/v1
+          alias: appsv1
+        - pkg: k8s.io/api/autoscaling/v2
+          alias: autoscalingv2
+        - pkg: k8s.io/api/batch/v1
+          alias: batchv1
+        - pkg: k8s.io/api/discovery/v1
+          alias: discoveryv1
+        - pkg: k8s.io/api/networking/v1
+          alias: networkingv1
+        - pkg: k8s.io/api/policy/v1
+          alias: policyv1
+        - pkg: k8s.io/api/rbac/v1
+          alias: rbacv1
+        - pkg: k8s.io/apimachinery/pkg/api/errors
+          alias: apierrors
+        - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+          alias: metav1
+        - pkg: sigs.k8s.io/gateway-api/apis/v1
+          alias: gwapiv1
+    nolintlint:
+      require-specific: true
     revive:
       rules:
         - name: exported
@@ -29,3 +72,9 @@ formatters:
   enable:
     - gofmt
     - goimports
+
+issues:
+  # Report everything instead of capping repeated findings (the defaults hide
+  # issues beyond 3 of the same kind, which makes CI runs non-exhaustive).
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/internal/controller/crashlooppolicy_controller.go
+++ b/internal/controller/crashlooppolicy_controller.go
@@ -243,10 +243,7 @@ func (r *CrashLoopPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	truncated := int32(0)
 	if len(activeScaledDown) > MaxActiveScaledDown {
-		omitted := len(activeScaledDown) - MaxActiveScaledDown
-		if omitted > math.MaxInt32 {
-			omitted = math.MaxInt32
-		}
+		omitted := min(len(activeScaledDown)-MaxActiveScaledDown, math.MaxInt32)
 		truncated = int32(omitted)
 		logger.Info("active scaled-down list truncated",
 			"limit", MaxActiveScaledDown, "omitted", omitted)

--- a/internal/controller/crashlooppolicy_controller_test.go
+++ b/internal/controller/crashlooppolicy_controller_test.go
@@ -71,7 +71,7 @@ func TestReconcile_SetsInitialPhase(t *testing.T) {
 func TestReconcile_ScalesDownDeployment(t *testing.T) {
 	policy := newCrashLoopPolicy("test-policy", withAllReplicasFailing(false))
 	deploy := newDeployment("my-app", testNamespace, 3)
-	rs := newReplicaSet("my-app-rs", testNamespace, "my-app", "deploy-uid-1")
+	rs := newReplicaSet("my-app-rs", testNamespace, "my-app")
 	pod := newFailingPod("my-app-pod-1", testNamespace, rsOwnerRef(), "CrashLoopBackOff", 15)
 
 	c := setupTestClient(policy, deploy, rs, pod)
@@ -172,7 +172,7 @@ func TestReconcile_SuspendsCronJob(t *testing.T) {
 func TestReconcile_SkipsExcludedNamespace(t *testing.T) {
 	policy := newCrashLoopPolicy("test-policy", withAllReplicasFailing(false))
 	deploy := newDeployment("my-app", "kube-system", 1)
-	rs := newReplicaSet("my-app-rs", "kube-system", "my-app", "deploy-uid-1")
+	rs := newReplicaSet("my-app-rs", "kube-system", "my-app")
 	pod := newFailingPod("my-app-pod-1", "kube-system", rsOwnerRef(), "CrashLoopBackOff", 15)
 
 	c := setupTestClient(policy, deploy, rs, pod)
@@ -195,7 +195,7 @@ func TestReconcile_SkipsExcludedNamespace(t *testing.T) {
 func TestReconcile_DryRunDoesNotScale(t *testing.T) {
 	policy := newCrashLoopPolicy("test-policy", withDryRun(true), withAllReplicasFailing(false))
 	deploy := newDeployment("my-app", testNamespace, 3)
-	rs := newReplicaSet("my-app-rs", testNamespace, "my-app", "deploy-uid-1")
+	rs := newReplicaSet("my-app-rs", testNamespace, "my-app")
 	pod := newFailingPod("my-app-pod-1", testNamespace, rsOwnerRef(), "CrashLoopBackOff", 15)
 
 	c := setupTestClient(policy, deploy, rs, pod)
@@ -226,7 +226,7 @@ func TestReconcile_BelowThresholdDoesNotScale(t *testing.T) {
 	// so the pod with 5 restarts and 1h age does not exceed either.
 	policy := newCrashLoopPolicy("test-policy", withRestartThreshold(20), withDurationThreshold("24h"), withAllReplicasFailing(false))
 	deploy := newDeployment("my-app", testNamespace, 1)
-	rs := newReplicaSet("my-app-rs", testNamespace, "my-app", "deploy-uid-1")
+	rs := newReplicaSet("my-app-rs", testNamespace, "my-app")
 	// Pod has only 5 restarts and was created 1h ago (below 24h duration threshold)
 	pod := newFailingPod("my-app-pod-1", testNamespace, rsOwnerRef(), "CrashLoopBackOff", 5)
 
@@ -250,9 +250,9 @@ func TestReconcile_BelowThresholdDoesNotScale(t *testing.T) {
 func TestReconcile_AllReplicasFailingRequired(t *testing.T) {
 	policy := newCrashLoopPolicy("test-policy", withAllReplicasFailing(true))
 	deploy := newDeployment("my-app", testNamespace, 2)
-	rs := newReplicaSet("my-app-rs", testNamespace, "my-app", "deploy-uid-1")
+	rs := newReplicaSet("my-app-rs", testNamespace, "my-app")
 	failingPod := newFailingPod("my-app-pod-1", testNamespace, rsOwnerRef(), "CrashLoopBackOff", 15)
-	healthyPod := newHealthyPod("my-app-pod-2", testNamespace, rsOwnerRef())
+	healthyPod := newHealthyPod("my-app-pod-2", rsOwnerRef())
 	// Set labels so the deployment selector matches
 	failingPod.Labels = map[string]string{"app": "my-app"}
 	healthyPod.Labels = map[string]string{"app": "my-app"}
@@ -371,7 +371,7 @@ func TestReconcile_NamespaceSelectorFilters(t *testing.T) {
 
 	// Deployment in dev namespace (should be scaled down)
 	devDeploy := newDeployment("dev-app", "dev-team", 1)
-	devRs := newReplicaSet("dev-app-rs", "dev-team", "dev-app", "deploy-uid-1")
+	devRs := newReplicaSet("dev-app-rs", "dev-team", "dev-app")
 	devPod := newFailingPod("dev-app-pod", "dev-team", metav1.OwnerReference{
 		APIVersion: "apps/v1",
 		Kind:       "ReplicaSet",
@@ -382,7 +382,7 @@ func TestReconcile_NamespaceSelectorFilters(t *testing.T) {
 	// Deployment in prod namespace (should NOT be scaled down)
 	prodDeploy := newDeployment("prod-app", "prod-team", 1)
 	prodDeploy.UID = "deploy-uid-2"
-	prodRs := newReplicaSet("prod-app-rs", "prod-team", "prod-app", "deploy-uid-2")
+	prodRs := newReplicaSet("prod-app-rs", "prod-team", "prod-app")
 	prodRs.OwnerReferences[0].UID = "deploy-uid-2"
 	prodPod := newFailingPod("prod-app-pod", "prod-team", metav1.OwnerReference{
 		APIVersion: "apps/v1",
@@ -432,7 +432,7 @@ func TestReconcile_ExcludeWorkloadSelectorSkipsWorkload(t *testing.T) {
 		"app":                         "my-app",
 		"argocd.argoproj.io/instance": "my-app",
 	}
-	rs := newReplicaSet("my-app-rs", testNamespace, "my-app", "deploy-uid-1")
+	rs := newReplicaSet("my-app-rs", testNamespace, "my-app")
 	pod := newFailingPod("my-app-pod-1", testNamespace, rsOwnerRef(), "CrashLoopBackOff", 15)
 
 	c := setupTestClient(policy, deploy, rs, pod)
@@ -462,7 +462,7 @@ func TestReconcile_ExcludeWorkloadSelectorAllowsNonMatching(t *testing.T) {
 
 	// Deployment without matching label should be scaled down
 	deploy := newDeployment("my-app", testNamespace, 3)
-	rs := newReplicaSet("my-app-rs", testNamespace, "my-app", "deploy-uid-1")
+	rs := newReplicaSet("my-app-rs", testNamespace, "my-app")
 	pod := newFailingPod("my-app-pod-1", testNamespace, rsOwnerRef(), "CrashLoopBackOff", 15)
 
 	c := setupTestClient(policy, deploy, rs, pod)
@@ -514,7 +514,7 @@ func TestReconcile_CronJobNotAllReplicasFailing(t *testing.T) {
 	cj := newCronJob("my-cj", testNamespace)
 	job := newJob("my-cj-job", testNamespace, "my-cj")
 	failingPod := newFailingPod("my-cj-pod-1", testNamespace, jobOwnerRef(), "CrashLoopBackOff", 15)
-	healthyPod := newHealthyPod("my-cj-pod-2", testNamespace, jobOwnerRef())
+	healthyPod := newHealthyPod("my-cj-pod-2", jobOwnerRef())
 
 	c := setupTestClient(policy, cj, job, failingPod, healthyPod)
 	r := newReconciler(c)
@@ -712,9 +712,9 @@ func TestReconcile_ExplicitAllReplicasFailingFalse(t *testing.T) {
 	// which would have kept this deployment running.
 	policy := newCrashLoopPolicy("test-policy", withAllReplicasFailing(false))
 	deploy := newDeployment("my-app", testNamespace, 2)
-	rs := newReplicaSet("my-app-rs", testNamespace, "my-app", "deploy-uid-1")
+	rs := newReplicaSet("my-app-rs", testNamespace, "my-app")
 	failingPod := newFailingPod("my-app-pod-1", testNamespace, rsOwnerRef(), "CrashLoopBackOff", 15)
-	healthyPod := newHealthyPod("my-app-pod-2", testNamespace, rsOwnerRef())
+	healthyPod := newHealthyPod("my-app-pod-2", rsOwnerRef())
 	failingPod.Labels = map[string]string{"app": "my-app"}
 	healthyPod.Labels = map[string]string{"app": "my-app"}
 
@@ -787,7 +787,7 @@ func TestReconcile_MostRestrictivePolicyWins(t *testing.T) {
 	strict := newCrashLoopPolicy("strict", withAllReplicasFailing(false), withRestartThreshold(5))
 	lax := newCrashLoopPolicy("lax", withAllReplicasFailing(false), withRestartThreshold(10))
 	deploy := newDeployment("my-app", testNamespace, 3)
-	rs := newReplicaSet("my-app-rs", testNamespace, "my-app", "deploy-uid-1")
+	rs := newReplicaSet("my-app-rs", testNamespace, "my-app")
 	pod := newFailingPod("my-app-pod-1", testNamespace, rsOwnerRef(), "CrashLoopBackOff", 15)
 
 	c := setupTestClient(strict, lax, deploy, rs, pod)
@@ -824,7 +824,7 @@ func TestReconcile_ActiveScaledDownAttributedToOwningPolicy(t *testing.T) {
 	strict := newCrashLoopPolicy("strict", withAllReplicasFailing(false), withRestartThreshold(5))
 	lax := newCrashLoopPolicy("lax", withAllReplicasFailing(false), withRestartThreshold(10))
 	deploy := newDeployment("my-app", testNamespace, 3)
-	rs := newReplicaSet("my-app-rs", testNamespace, "my-app", "deploy-uid-1")
+	rs := newReplicaSet("my-app-rs", testNamespace, "my-app")
 	pod := newFailingPod("my-app-pod-1", testNamespace, rsOwnerRef(), "CrashLoopBackOff", 15)
 
 	c := setupTestClient(strict, lax, deploy, rs, pod)
@@ -991,7 +991,7 @@ func TestDurationPatternMatchesAcceptedValues(t *testing.T) {
 }
 
 func TestPodWaitingReasons(t *testing.T) {
-	healthy := newHealthyPod("healthy", testNamespace, rsOwnerRef())
+	healthy := newHealthyPod("healthy", rsOwnerRef())
 	if got := podWaitingReasons(healthy); len(got) != 0 {
 		t.Errorf("expected no reasons for a healthy pod, got %v", got)
 	}
@@ -1009,7 +1009,7 @@ func TestPodWaitingReasons(t *testing.T) {
 }
 
 func TestPodHasWaitingContainer(t *testing.T) {
-	if podHasWaitingContainer(newHealthyPod("healthy", testNamespace, rsOwnerRef())) {
+	if podHasWaitingContainer(newHealthyPod("healthy", rsOwnerRef())) {
 		t.Error("healthy pod should not pass the watch predicate")
 	}
 	if !podHasWaitingContainer(newFailingPod("failing", testNamespace, rsOwnerRef(), "ImagePullBackOff", 1)) {
@@ -1019,7 +1019,7 @@ func TestPodHasWaitingContainer(t *testing.T) {
 
 func TestListPodsByWaitingReasons_DeduplicatesAndFilters(t *testing.T) {
 	failing := newFailingPod("failing", testNamespace, rsOwnerRef(), "CrashLoopBackOff", 3)
-	healthy := newHealthyPod("healthy", testNamespace, rsOwnerRef())
+	healthy := newHealthyPod("healthy", rsOwnerRef())
 	c := setupTestClient(failing, healthy)
 
 	// Passing the reason twice must not yield the pod twice.

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -3,13 +3,14 @@ package controller
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -156,7 +157,7 @@ func resolveOwnerWorkload(ctx context.Context, c client.Client, pod *corev1.Pod)
 	case "ReplicaSet":
 		rs := &appsv1.ReplicaSet{}
 		if err := c.Get(ctx, types.NamespacedName{Name: ownerRef.Name, Namespace: ns}, rs); err != nil {
-			if errors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				return nil, nil
 			}
 			return nil, err
@@ -172,7 +173,7 @@ func resolveOwnerWorkload(ctx context.Context, c client.Client, pod *corev1.Pod)
 	case "Job":
 		job := &batchv1.Job{}
 		if err := c.Get(ctx, types.NamespacedName{Name: ownerRef.Name, Namespace: ns}, job); err != nil {
-			if errors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				return nil, nil
 			}
 			return nil, err
@@ -189,22 +190,12 @@ func resolveOwnerWorkload(ctx context.Context, c client.Client, pod *corev1.Pod)
 
 // isTargetKind checks if a workload kind is in the targets list.
 func isTargetKind(kind string, targets []string) bool {
-	for _, t := range targets {
-		if t == kind {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(targets, kind)
 }
 
 // isExcludedNamespace checks if a namespace is in the exclude list.
 func isExcludedNamespace(ns string, excluded []string) bool {
-	for _, e := range excluded {
-		if e == ns {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(excluded, ns)
 }
 
 // workloadKey returns a unique string key for a workload.
@@ -373,7 +364,7 @@ func scaleDownWorkload(ctx context.Context, c client.Client, owner *ownerWorkloa
 			if prevReplicas == 0 {
 				return nil
 			}
-			deploy.Spec.Replicas = int32Ptr(0)
+			deploy.Spec.Replicas = new(int32(0))
 			if deploy.Annotations == nil {
 				deploy.Annotations = make(map[string]string)
 			}
@@ -410,7 +401,7 @@ func scaleDownWorkload(ctx context.Context, c client.Client, owner *ownerWorkloa
 			if prevReplicas == 0 {
 				return nil
 			}
-			sts.Spec.Replicas = int32Ptr(0)
+			sts.Spec.Replicas = new(int32(0))
 			if sts.Annotations == nil {
 				sts.Annotations = make(map[string]string)
 			}
@@ -443,7 +434,7 @@ func scaleDownWorkload(ctx context.Context, c client.Client, owner *ownerWorkloa
 			if cj.Spec.Suspend != nil && *cj.Spec.Suspend {
 				return nil
 			}
-			cj.Spec.Suspend = boolPtr(true)
+			cj.Spec.Suspend = new(true)
 			if cj.Annotations == nil {
 				cj.Annotations = make(map[string]string)
 			}

--- a/internal/controller/ptr.go
+++ b/internal/controller/ptr.go
@@ -1,4 +1,0 @@
-package controller
-
-func int32Ptr(i int32) *int32 { return &i }
-func boolPtr(b bool) *bool    { return &b }

--- a/internal/controller/testutil_test.go
+++ b/internal/controller/testutil_test.go
@@ -72,11 +72,11 @@ func newCrashLoopPolicy(name string, opts ...policyOption) *crashloopv1alpha1.Cr
 			WatchReasons:       []string{"CrashLoopBackOff", "ImagePullBackOff", "ErrImagePull", "CreateContainerConfigError", "InvalidImageName", "RunContainerError"},
 			RestartThreshold:   10,
 			DurationThreshold:  "30m",
-			AllReplicasFailing: boolPtr(true),
+			AllReplicasFailing: new(true),
 			Targets:            []string{"Deployment", "StatefulSet", "CronJob"},
 			ExcludeNamespaces:  []string{"kube-system", "kube-public", "kube-node-lease"},
 			ReconcileInterval:  "60s",
-			DryRun:             boolPtr(false),
+			DryRun:             new(false),
 		},
 	}
 	for _, o := range opts {
@@ -87,7 +87,7 @@ func newCrashLoopPolicy(name string, opts ...policyOption) *crashloopv1alpha1.Cr
 
 func withDryRun(dryRun bool) policyOption {
 	return func(p *crashloopv1alpha1.CrashLoopPolicy) {
-		p.Spec.DryRun = boolPtr(dryRun)
+		p.Spec.DryRun = new(dryRun)
 	}
 }
 
@@ -99,7 +99,7 @@ func withRestartThreshold(t int32) policyOption {
 
 func withAllReplicasFailing(v bool) policyOption {
 	return func(p *crashloopv1alpha1.CrashLoopPolicy) {
-		p.Spec.AllReplicasFailing = boolPtr(v)
+		p.Spec.AllReplicasFailing = new(v)
 	}
 }
 
@@ -169,11 +169,11 @@ func newFailingPod(name, namespace string, ownerRef metav1.OwnerReference, reaso
 	return pod
 }
 
-func newHealthyPod(name, namespace string, ownerRef metav1.OwnerReference) *corev1.Pod {
+func newHealthyPod(name string, ownerRef metav1.OwnerReference) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            name,
-			Namespace:       namespace,
+			Namespace:       testNamespace,
 			OwnerReferences: []metav1.OwnerReference{ownerRef},
 		},
 		Status: corev1.PodStatus{
@@ -206,7 +206,7 @@ func newDeployment(name, namespace string, replicas int32) *appsv1.Deployment {
 			UID:       "deploy-uid-1",
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: int32Ptr(replicas),
+			Replicas: new(replicas),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"app": name},
 			},
@@ -222,7 +222,7 @@ func newDeployment(name, namespace string, replicas int32) *appsv1.Deployment {
 	}
 }
 
-func newReplicaSet(name, namespace, deploymentName string, deploymentUID string) *appsv1.ReplicaSet {
+func newReplicaSet(name, namespace, deploymentName string) *appsv1.ReplicaSet {
 	return &appsv1.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -253,7 +253,7 @@ func newStatefulSet(name, namespace string, replicas int32) *appsv1.StatefulSet 
 			UID:       "sts-uid-1",
 		},
 		Spec: appsv1.StatefulSetSpec{
-			Replicas: int32Ptr(replicas),
+			Replicas: new(replicas),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"app": name},
 			},


### PR DESCRIPTION
## Summary

Replaces the smaller linter set added in #21 with the shared configuration from [slauger/coding-standards](https://github.com/slauger/coding-standards) (`golang/examples/.golangci.yml`), which follows what cluster-api, cert-manager, CloudNativePG and external-secrets converged on.

The file is a **byte-identical copy** of the standard, including the importas aliases for packages this project does not import. Keeping it identical means the next update to the standard is a plain copy rather than a merge, which is the whole point of having one.

Notable additions: `bodyclose`, `copyloopvar`, `gocritic`, `importas` with `no-unaliased`, `loggercheck`, `modernize`, `nilerr`, `nolintlint`, `prealloc`, `unparam`, the `asciicheck`/`bidichk` pair, `goimports` as an enforced formatter, and issue caps disabled so CI reports every finding instead of hiding repeats past the default of three.

**15 findings, all mechanical**, but two needed a judgement call rather than just accepting `--fix`:

- `modernize` rewrote the pointer helpers onto the `new(expr)` form Go 1.26 allows and inlined most call sites, which left `boolPtr` unused and `int32Ptr` flagged as "should be inlined". Rather than leave a half-migrated helper file, I deleted `internal/controller/ptr.go` entirely and let the last two callers construct the pointer directly. The helpers only ever existed to work around the language not having this.
- `unparam` found a parameter `newReplicaSet` never used and one on `newHealthyPod` that only ever received the default namespace. Both dropped; adding a parameter back is trivial if a future test needs it.

Prompted by the openvox-operator session, where the same change produced roughly 120 findings. This repo had far fewer because #21 already enabled `errorlint`, `gosec`, `misspell`, `revive` and `unconvert`.

## Test plan

- `golangci-lint run` reports 0 issues with the new config, verified at the version CI pins (v2.13.2).
- `make ci` passes end to end; coverage 59.7 percent against the 55 percent gate.
- `go build` and `go vet` are clean, and the full test suite including envtest passes, which matters because `modernize` rewrote code rather than only formatting it.
