### PR TITLE
docs: add a troubleshooting guide and rewrite AGENT.md

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,6 @@ on:
     branches: [main, develop]
     paths-ignore:
       - '**/*.md'
-      - 'docs/**'
       - 'LICENSE'
       - 'CHANGELOG*'
       - '.github/*.md'
@@ -13,7 +12,6 @@ on:
     branches: [main, develop]
     paths-ignore:
       - '**/*.md'
-      - 'docs/**'
       - 'LICENSE'
       - 'CHANGELOG*'
       - '.github/*.md'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -5,7 +5,6 @@ on:
     branches: [main, develop]
     paths-ignore:
       - "**/*.md"
-      - docs/**
       - LICENSE
       - CHANGELOG*
       - .github/*.md
@@ -13,7 +12,6 @@ on:
     branches: [develop]
     paths-ignore:
       - "**/*.md"
-      - docs/**
       - LICENSE
       - CHANGELOG*
       - .github/*.md

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,88 +1,96 @@
 # Agent Instructions
 
-## Git Workflow
+[CONTRIBUTING.md](CONTRIBUTING.md) is the source of truth for prerequisites,
+the branching model, commit conventions, the test layout and the documentation
+mapping table. Read it first. This file covers only what an agent needs beyond
+it, so the two cannot drift apart.
 
-- **Development branch:** `develop`
-- **Release branch:** `main` (only receives merges from `develop` via auto-PR)
-- **Always branch from `origin/develop`**, never from `main`
-- **PRs target `develop`** (`--base develop`)
-- Branch naming: `feat/<topic>` or `fix/<topic>`
-
-```bash
-git fetch origin develop
-git checkout -b feat/my-feature origin/develop
-# ... work ...
-gh pr create --base develop
-```
-
-## Merge Strategy
-
-- **Feature/fix PRs into `develop`:** Use standard merge by default. Use squash only when the branch has many noisy commits that logically belong together (e.g. lots of trial-and-error or CI fix-ups).
-- **`develop` into `main`:** Always rebase, so that `develop` and `main` stay identical after merge.
-
-## Commit Messages
-
-Follow [Conventional Commits](https://www.conventionalcommits.org/). Semantic-release on `main` uses these to determine version bumps.
-
-```
-feat: add CrashLoopPolicy CRD and controller
-fix: handle nil ownerReferences in pod watcher
-docs: update README for installation
-ci: add container build workflow
-chore: update dependencies
-refactor: simplify owner resolution logic
-test: add unit tests for pod failure detection
-```
-
-- Lowercase subject, no trailing period
-- `feat:` triggers a minor version bump
-- `fix:` triggers a patch version bump
-- Append `BREAKING CHANGE:` in the body for major bumps
-
-## Pull Requests
-
-- Title follows conventional commit format
-- Keep the title short (under 72 chars)
-- Body should include a `## Summary` with bullet points and a `## Test plan`
-- Reference related issues with `Closes #<number>`
-- PRs always target `develop`, not `main`
-
-## Build & Test
+## Before you finish
 
 ```bash
-make generate manifests   # regenerate deepcopy + CRD YAML + Helm CRDs
-go build ./...
-go vet ./...
-go test ./internal/controller/ -v
-make ci                   # full CI: lint + test + helm-lint + check-manifests
+make ci
 ```
 
-Always run `make generate manifests` after modifying `api/v1alpha1/*_types.go`.
-Always run `make check-manifests` before committing to verify generated files are up to date.
+Everything CI runs. It is not optional: several checks exist precisely because
+generated files silently fall out of step, and they fail the build rather than
+warn.
 
-## Project Structure
+- `make generate manifests` after touching `api/v1alpha1/*_types.go` or any
+  `+kubebuilder:` marker, including the RBAC markers.
+- `make helm-docs helm-schema` after editing `charts/crashloop-operator/values.yaml`.
+- `go mod tidy` after adding an import. `make check-tidy` covers it, but only
+  since it was added; older habits assumed CI alone would catch it.
+
+## Release model
+
+`develop` is the only branch you work on. **Do not create or push to `main`,
+do not merge into it, and do not cut releases** - the maintainer owns that path
+deliberately. The auto-PR workflow targets `main` and will fail while the branch
+does not exist; that is expected and not a defect to fix.
+
+While the project is pre-1.0, `.releaserc.json` releases a breaking change as a
+**minor** version, not a major. Mark breaking changes with `!` or a
+`BREAKING CHANGE:` footer anyway, and say in the body what users must change.
+
+## Documentation scope
+
+There is deliberately **no mkdocs site**. The project has a single CRD, so
+documentation lives in `README.md`, `CONTRIBUTING.md`, `SECURITY.md` and the
+generated chart README. Do not add a `docs/` tree.
+
+Documentation is part of the change, not a follow-up. The mapping table in
+CONTRIBUTING.md says which document each kind of change touches.
+
+## Project structure
 
 ```
-api/v1alpha1/              CRD type definitions (Go structs)
-internal/controller/       Reconciler, helpers, tests
+api/v1alpha1/              CRD types, plus the envtest suite that runs them
+                           against a real API server
+internal/controller/       Reconciler, helpers, policy resolution, tests
 config/crd/bases/          Generated CRD YAML
-charts/crashloop-operator/ Helm chart (CRDs copied from config/crd/bases/)
+config/rbac/               Generated RBAC, compared against the chart by
+                           hack/check-rbac.sh
+config/samples/            Hand-written examples, validated by envtest
+charts/crashloop-operator/ Helm chart; CRDs copied from config/crd/bases/
+tests/e2e/                 Chainsaw tests, run on kind in CI
+hack/                      Coverage and RBAC check scripts
 images/                    Containerfiles
 cmd/                       Entrypoint
 ```
 
-## Code Conventions
+## Code conventions
 
-- Controller tests use the builder pattern from `testutil_test.go` (`newCrashLoopPolicy()` with option funcs)
-- Use `updateStatusWithRetry` for all status updates
-- Follow existing patterns for reconciler structure
+- Read defaulted spec fields through the `effective*` accessors in
+  `internal/controller/policyresolve.go`. Repeating a fallback inline creates a
+  second source of truth next to the kubebuilder default.
+- Use `updatePolicyStatusIfChanged` for status writes. `updateStatusWithRetry`
+  still exists for the initial phase write, but the former skips the write when
+  nothing changed, which is what keeps the operator from rewriting its own
+  object every interval.
+- Count errors inside the reconcile loop rather than swallowing them, so the
+  `Ready` condition can report `ReconcilePartiallyFailed`. A loop that logs and
+  continues without counting makes a broken policy look healthy.
+- Controller tests use the builder pattern in `testutil_test.go`. Anything that
+  depends on defaulting, schema validation or the status subresource belongs in
+  the envtest suite instead, because the fake client applies none of it.
 
-## Text Quality
+## Text quality
 
-- **No Unicode em-dashes, smart quotes, or other non-ASCII punctuation.** Use plain ASCII (`-`, `--`, `'`, `"`).
-- CI runs a unicode-lint check that rejects zero-width characters, soft hyphens, word joiners, and similar invisible characters.
-- When in doubt, stick to plain ASCII in all files (code, docs, comments, commit messages).
+Plain ASCII everywhere: code, comments, documentation and commit messages. No
+em-dashes, smart quotes, or other non-ASCII punctuation. CI rejects zero-width
+characters, soft hyphens, word joiners and similar invisible characters, and
+`asciicheck`/`bidichk` enforce the same in Go sources.
 
-## Documentation
+## Linting
 
-- No CHANGELOG -- release notes are auto-generated from commit messages by semantic-release
+`.golangci.yml` is a byte-identical copy of `golang/examples/.golangci.yml` from
+[slauger/coding-standards](https://github.com/slauger/coding-standards). Do not
+hand-edit it; update it by copying the standard again, so the next update stays
+a copy rather than a merge.
+
+`modernize` rewrites real code, not just formatting. After
+`golangci-lint run --fix`, run the full build and test suite before committing.
+
+## No CHANGELOG
+
+Release notes are generated from commit messages by semantic-release.

--- a/README.md
+++ b/README.md
@@ -179,6 +179,100 @@ Restrictiveness is compared in this order, and the first difference decides:
 Because the order is total, the winner does not depend on the order in which
 policies are evaluated.
 
+## Troubleshooting
+
+### The policy exists but nothing is scaled down
+
+Check the policy first:
+
+```bash
+kubectl get clp
+kubectl describe clp default
+```
+
+`Phase: Pending` means the policy has not been evaluated yet. `Phase: Active`
+with `Degraded: False` means it ran and found nothing to act on. In that case
+work through the conditions the operator applies, in the order it applies them:
+
+- **`dryRun` is true.** The operator logs and emits `WorkloadScaleDownDryRun`
+  events for everything it would have acted on, and changes nothing. This is
+  the intended starting point for a new policy.
+- **Neither threshold is exceeded.** A workload is only acted on once
+  `restartThreshold` restarts are reached **or** the pod has been failing for
+  `durationThreshold`. A pod that never starts has no restarts, so it is the
+  duration that applies.
+- **`allReplicasFailing` is true and some replica is healthy.** This defaults to
+  true, so a Deployment with one broken and one running pod is left alone by
+  design. Set it to `false` if you want partial failure to count.
+- **The namespace is excluded.** `excludeNamespaces` defaults to `kube-system`,
+  `kube-public` and `kube-node-lease`. Setting the field **replaces** that
+  default rather than adding to it.
+- **`namespaceSelector` or `excludeWorkloadSelector` filters it out.**
+- **The failure reason is not watched.** `watchReasons` matches the container's
+  waiting reason exactly. Check it with
+  `kubectl get pod <pod> -o jsonpath='{.status.containerStatuses[*].state.waiting.reason}'`.
+
+### Ready is False
+
+```
+Reason: ReconcilePartiallyFailed
+```
+
+The evaluation completed but hit errors on individual workloads, for example a
+workload it could not read. The operator does not abort the rest of the run.
+The operator logs name the workload:
+
+```bash
+kubectl -n crashloop-system logs -l app.kubernetes.io/name=crashloop-operator
+```
+
+### A workload was scaled down and I want to know why
+
+Every action is recorded on the workload itself:
+
+```bash
+kubectl get deployment my-app -o jsonpath='{.metadata.annotations}' | jq
+```
+
+`scaled-down-reason` carries the failure reason and the policy name,
+`scaled-down-at` the timestamp, `scaled-down-by` the policy that acted, and
+`previous-replicas` the replica count to restore. The operator also emits a
+`WorkloadScaledDown` event on the policy:
+
+```bash
+kubectl get events --field-selector involvedObject.name=default
+```
+
+### Several policies match the same workload
+
+Only one acts: the most restrictive one, as described under
+[Multiple Policies](#multiple-policies). `scaled-down-by` names it. The other
+policies leave the workload out of their `activeScaledDown` list and do not
+count it, which is why a policy you expected to act may show a counter of zero.
+
+### Restoring a scaled-down workload
+
+The operator never scales anything back up, so that recovery stays with
+whatever manages your workloads. To do it by hand:
+
+```bash
+kubectl scale deployment my-app \
+  --replicas="$(kubectl get deployment my-app \
+    -o jsonpath='{.metadata.annotations.crashloop-operator\.lauger\.de/previous-replicas}')"
+```
+
+For a CronJob, unset `spec.suspend`. Note that the operator will act again on
+the next evaluation if the underlying failure persists.
+
+### The CRD is out of date after a chart upgrade
+
+Helm installs CRDs from the chart's `crds/` directory but never upgrades or
+deletes them. After an upgrade that changes the CRD, apply it yourself:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/slauger/crashloop-operator/develop/config/crd/bases/crashloop-operator.lauger.de_crashlooppolicies.yaml
+```
+
 ## Local Development
 
 ```bash


### PR DESCRIPTION
## Summary

Closes out #28 with the scope you decided: **no mkdocs site.** One CRD does not justify a second place to keep documentation in sync, and the README already covers spec, status, architecture, multi-policy semantics and supply-chain verification.

**Troubleshooting section.** The genuinely missing piece. It walks the checks in the order the reconciler applies them, so the common report of "the policy exists but nothing happens" resolves to a specific cause rather than guesswork: `dryRun`, thresholds not reached, `allReplicasFailing` holding on a partly healthy workload, a namespace excluded by a default that a set value *replaces* rather than extends, or a failure reason outside `watchReasons`. Also covers `Ready=False`, tracing an action through the annotations, what happens when policies overlap, restoring a scaled-down workload, and the CRD not being upgraded by Helm.

**AGENT.md rewritten as a layer on top of CONTRIBUTING.md** instead of a parallel copy. The two had already drifted into an outright contradiction: AGENT.md still said `BREAKING CHANGE` gives a major bump, which stopped being true when `.releaserc.json` was set to release breaking changes as minor pre-1.0. Duplicating branching, commits, testing and the doc mapping table in both files guarantees that recurring, so AGENT.md now points at CONTRIBUTING.md and carries only what an agent needs beyond it.

It also records things that were true but written nowhere: that `main` and releases belong to you, that the failing auto-PR runs on develop are expected rather than a defect to go fix, the `effective*` accessor and error-counting conventions added since it was written, and that `.golangci.yml` is a copy of the shared standard and should be updated by copying rather than editing.

**Removed the `docs/**` paths-ignore entries** from the CI and E2E workflows, which pointed at a directory that will now never exist.

Closes #28

## Test plan

- Every path, helper and file AGENT.md references was checked to exist: `hack/check-rbac.sh`, `internal/controller/policyresolve.go`, `tests/e2e/`, `config/rbac/`, both status helpers, the `check-tidy` target.
- Confirmed AGENT.md and CONTRIBUTING.md now agree on the pre-1.0 breaking-change rule.
- The troubleshooting content is grounded in the actual condition reasons and event reasons the code emits (`ReconcilePartiallyFailed`, `WorkloadScaledDown`, `WorkloadScaleDownDryRun`), not invented ones.
- `make ci` passes; `actionlint` clean on both changed workflows.
