### PR TITLE
feat(build): base the runtime image on ubi9-micro

### DIFF
--- a/images/crashloop-operator/Containerfile
+++ b/images/crashloop-operator/Containerfile
@@ -30,7 +30,13 @@ RUN --mount=type=cache,target=/root/.cache/go-build,sharing=locked \
         -X main.buildDate=${BUILD_DATE}" \
       -o manager ./cmd/main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1788166357@sha256:7fbeae18dc9476399f565e68255f602a3374ea8614ba3d14843565131a13ff93
+# ubi-micro rather than ubi-minimal: same Red Hat provenance and CVE feed, but
+# without a package manager, which the operator has no use for. It ships no
+# system CA bundle, which is fine because client-go reads the API server CA
+# from the ServiceAccount volume rather than the system trust store. Anything
+# added later that calls an external HTTPS endpoint would fail with x509
+# errors here and would need the certificates copied in.
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.8-1787778798@sha256:f332c99eb8f798a8486821c91937f10ad64ee83d7e739303be2df051040918f6
 
 ARG VERSION=dev
 ARG COMMIT=unknown


### PR DESCRIPTION
## Summary

Switches the runtime stage from `ubi9/ubi-minimal` to `ubi9/ubi-micro`, keeping the Red Hat provenance, CVE feed and certification path while dropping most of the image.

Measured, all three built from this same Containerfile with only the runtime stage differing:

| Runtime base | Size | Red Hat |
|---|---|---|
| ubi9-minimal (before) | 140 MB | yes |
| **ubi9-micro (this PR)** | **56 MB** | yes |
| distroless/static | 35 MB | no |

ubi-minimal ships a package manager and a userland this operator never touches, and every one of those packages is a CVE an enterprise scanner will raise a ticket for, on code that never executes. ubi-micro removes that without leaving the Red Hat ecosystem, which is the trade distroless would have forced.

**One constraint worth knowing, now recorded in the Containerfile.** ubi-micro ships no system CA bundle. That is fine today: client-go reads the API server CA from the ServiceAccount volume, not the system trust store, and the operator makes no external calls. But anything added later that talks to an external HTTPS endpoint will fail with x509 errors, and the cause would not be obvious from the symptom.

The Conforma policy needs no change, since the registry prefix is unchanged.

Closes #56

## Test plan

- Built the image with build args and ran it: `--version` reports correctly, so the static binary runs on micro without the glibc userland minimal provides.
- Inspected the exported filesystem to confirm the CA bundle really is absent rather than assuming it, which is what the Containerfile comment is based on: 885 files total, no `ca-bundle` anywhere under `/etc/pki`.
- Pinned by digest alongside the readable tag, same as before, so renovate keeps tracking it.
- `hadolint` clean, `make ci` passes.
- The E2E job on this PR is the real check: it builds this image, loads it into kind and asserts the operator actually reconciles a workload.
