### PR TITLE
feat(controller): expose Prometheus metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,9 +159,9 @@ GENERATED_PATHS = api/v1alpha1/zz_generated.deepcopy.go config/crd/bases config/
 .PHONY: check-tidy
 check-tidy: ## Check go.mod and go.sum are tidy.
 	@go mod tidy
-	@if ! git diff --quiet -- go.mod go.sum; then \
+	@if ! git diff HEAD --quiet -- go.mod go.sum; then \
 		echo "error: go.mod or go.sum is not tidy. Run 'go mod tidy' and commit the result."; \
-		git diff --stat -- go.mod go.sum; \
+		git diff HEAD --stat -- go.mod go.sum; \
 		exit 1; \
 	fi
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,53 @@ Restrictiveness is compared in this order, and the first difference decides:
 Because the order is total, the winner does not depend on the order in which
 policies are evaluated.
 
+## Metrics
+
+The operator serves Prometheus metrics on port 8080. The chart does not expose
+them by default:
+
+```bash
+helm upgrade --install crashloop-operator oci://ghcr.io/slauger/charts/crashloop-operator \
+  --set metrics.service.enabled=true \
+  --set metrics.serviceMonitor.enabled=true
+```
+
+The `serviceMonitor` option needs the Prometheus Operator CRDs. The endpoint is
+unauthenticated, so restrict access if you expose it; see
+[SECURITY.md](SECURITY.md#metrics-endpoint).
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `crashloop_scaled_down_total` | Counter | `policy`, `namespace`, `kind`, `reason`, `dry_run` | Actions taken, including dry-run ones |
+| `crashloop_workloads_scaled_down` | Gauge | `policy` | Workloads the policy is currently holding at zero |
+| `crashloop_policy_evaluation_errors_total` | Counter | `policy` | Per-workload errors that did not fail the reconcile |
+| `crashloop_policy_ready` | Gauge | `policy` | 1 when the last evaluation completed without errors |
+
+Alongside these, controller-runtime exports the usual
+`controller_runtime_reconcile_*` and `workqueue_*` metrics.
+
+No metric carries a workload name. Namespaces are bounded by the cluster,
+workload names are not, and a series for a workload that is later deleted would
+never go away. Use `status.activeScaledDown` or the `scaled-down-by` annotation
+to identify individual workloads.
+
+Two alerts worth having:
+
+```yaml
+# A policy has been failing on individual workloads.
+- alert: CrashLoopPolicyDegraded
+  expr: crashloop_policy_ready == 0
+  for: 15m
+
+# Something has been held at zero replicas for a day and nobody noticed.
+- alert: WorkloadScaledDownTooLong
+  expr: crashloop_workloads_scaled_down > 0
+  for: 24h
+```
+
+Note that `crashloop_scaled_down_total` counts dry-run actions too. Filter with
+`dry_run="false"` when alerting on real ones.
+
 ## Troubleshooting
 
 ### The policy exists but nothing is scaled down

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/slauger/crashloop-operator
 go 1.26.6
 
 require (
+	github.com/prometheus/client_golang v1.24.0
 	k8s.io/api v0.37.0
 	k8s.io/apimachinery v0.37.0
 	k8s.io/client-go v0.37.0
@@ -40,13 +41,13 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.24.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.0 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect

--- a/internal/controller/crashlooppolicy_controller.go
+++ b/internal/controller/crashlooppolicy_controller.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -47,6 +49,11 @@ func (r *CrashLoopPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	policy := &crashloopv1alpha1.CrashLoopPolicy{}
 	if err := r.Get(ctx, req.NamespacedName, policy); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Drop the per-policy series, otherwise the gauges keep reporting
+			// on an object that no longer exists.
+			forgetPolicyMetrics(req.Name)
+		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
@@ -217,6 +224,9 @@ func (r *CrashLoopPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 		if acted {
 			scaledDown++
+			scaledDownTotal.WithLabelValues(
+				policy.Name, owner.Namespace, owner.Kind, reason, strconv.FormatBool(dryRun),
+			).Inc()
 			eventReason := EventReasonScaledDown
 			eventMsg := fmt.Sprintf("Scaled down %s %s/%s: %s", owner.Kind, owner.Namespace, owner.Name, scaleReason)
 			if owner.Kind == "CronJob" {
@@ -248,6 +258,12 @@ func (r *CrashLoopPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		logger.Info("active scaled-down list truncated",
 			"limit", MaxActiveScaledDown, "omitted", omitted)
 		activeScaledDown = activeScaledDown[:MaxActiveScaledDown]
+	}
+
+	workloadsScaledDown.WithLabelValues(policy.Name).Set(float64(len(activeScaledDown)) + float64(truncated))
+	policyReady.WithLabelValues(policy.Name).Set(boolToFloat(loopErrors == 0))
+	if loopErrors > 0 {
+		policyEvaluationErrors.WithLabelValues(policy.Name).Add(float64(loopErrors))
 	}
 
 	// Update status with conditions

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -1,0 +1,85 @@
+package controller
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// Metrics exported by the operator. controller-runtime already registers
+// reconcile counts, errors, durations and the workqueue metrics, so nothing
+// here duplicates those: these cover what only this operator knows.
+//
+// No metric carries a workload name. Namespaces are bounded by the cluster,
+// but workload names are not, and a series for a workload that is later
+// deleted would never go away. Workload identity lives in
+// status.activeScaledDown and the scaled-down-by annotation instead.
+var (
+	// scaledDownTotal counts actions taken. The dry_run label matters: while a
+	// policy is in dry-run you specifically want to see what it would have
+	// done, and without the label that is indistinguishable from a real
+	// action.
+	scaledDownTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "crashloop_scaled_down_total",
+			Help: "Total workloads scaled down or suspended, including dry-run actions.",
+		},
+		[]string{"policy", "namespace", "kind", "reason", "dry_run"},
+	)
+
+	// workloadsScaledDown reports how many workloads a policy is currently
+	// holding at zero. A value that stays above zero for a long time is the
+	// interesting alert: something has been down and nobody noticed.
+	workloadsScaledDown = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "crashloop_workloads_scaled_down",
+			Help: "Workloads currently scaled down or suspended by this policy.",
+		},
+		[]string{"policy"},
+	)
+
+	// policyEvaluationErrors covers a blind spot. Per-workload failures are
+	// counted and surfaced through the Ready condition but deliberately do not
+	// fail the reconcile, so controller_runtime_reconcile_errors_total stays
+	// at zero while a policy quietly fails on every workload it looks at.
+	policyEvaluationErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "crashloop_policy_evaluation_errors_total",
+			Help: "Per-workload errors during evaluation that did not fail the reconcile.",
+		},
+		[]string{"policy"},
+	)
+
+	// policyReady mirrors the Ready condition so it can be alerted on directly.
+	policyReady = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "crashloop_policy_ready",
+			Help: "1 when the policy's last evaluation completed without errors, 0 otherwise.",
+		},
+		[]string{"policy"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		scaledDownTotal,
+		workloadsScaledDown,
+		policyEvaluationErrors,
+		policyReady,
+	)
+}
+
+// forgetPolicyMetrics drops the per-policy series for a policy that no longer
+// exists. Without this the gauges keep reporting on a deleted object forever.
+func forgetPolicyMetrics(name string) {
+	workloadsScaledDown.DeleteLabelValues(name)
+	policyReady.DeleteLabelValues(name)
+	policyEvaluationErrors.DeleteLabelValues(name)
+}
+
+// boolToFloat maps a boolean onto the 1/0 convention Prometheus gauges use.
+func boolToFloat(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/internal/controller/metrics_test.go
+++ b/internal/controller/metrics_test.go
@@ -1,0 +1,130 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// resetMetrics clears the collectors so each test starts from a known state.
+// The collectors are package-level and registered once in init, so they carry
+// over between tests otherwise.
+func resetMetrics() {
+	scaledDownTotal.Reset()
+	workloadsScaledDown.Reset()
+	policyEvaluationErrors.Reset()
+	policyReady.Reset()
+}
+
+func TestMetrics_ScaleDownIsCounted(t *testing.T) {
+	resetMetrics()
+
+	policy := newCrashLoopPolicy("metrics-policy", withAllReplicasFailing(false))
+	deploy := newDeployment("my-app", testNamespace, 3)
+	rs := newReplicaSet("my-app-rs", testNamespace, "my-app")
+	pod := newFailingPod("my-app-pod-1", testNamespace, rsOwnerRef(), "CrashLoopBackOff", 15)
+
+	c := setupTestClient(policy, deploy, rs, pod)
+	r := newReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("metrics-policy")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := `
+# HELP crashloop_scaled_down_total Total workloads scaled down or suspended, including dry-run actions.
+# TYPE crashloop_scaled_down_total counter
+crashloop_scaled_down_total{dry_run="false",kind="Deployment",namespace="default",policy="metrics-policy",reason="CrashLoopBackOff"} 1
+`
+	if err := testutil.CollectAndCompare(scaledDownTotal, strings.NewReader(expected)); err != nil {
+		t.Errorf("unexpected metric: %v", err)
+	}
+
+	if got := testutil.ToFloat64(workloadsScaledDown.WithLabelValues("metrics-policy")); got != 1 {
+		t.Errorf("expected 1 workload held down, got %v", got)
+	}
+	if got := testutil.ToFloat64(policyReady.WithLabelValues("metrics-policy")); got != 1 {
+		t.Errorf("expected policy to report ready, got %v", got)
+	}
+}
+
+// TestMetrics_DryRunIsDistinguishable is the reason the dry_run label exists:
+// a simulated action must not look like a real one.
+func TestMetrics_DryRunIsDistinguishable(t *testing.T) {
+	resetMetrics()
+
+	policy := newCrashLoopPolicy("dry-policy", withDryRun(true), withAllReplicasFailing(false))
+	deploy := newDeployment("my-app", testNamespace, 3)
+	rs := newReplicaSet("my-app-rs", testNamespace, "my-app")
+	pod := newFailingPod("my-app-pod-1", testNamespace, rsOwnerRef(), "CrashLoopBackOff", 15)
+
+	c := setupTestClient(policy, deploy, rs, pod)
+	r := newReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("dry-policy")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := testutil.ToFloat64(scaledDownTotal.WithLabelValues(
+		"dry-policy", testNamespace, "Deployment", "CrashLoopBackOff", "true")); got != 1 {
+		t.Errorf("expected the dry-run action to be counted with dry_run=true, got %v", got)
+	}
+	if got := testutil.ToFloat64(scaledDownTotal.WithLabelValues(
+		"dry-policy", testNamespace, "Deployment", "CrashLoopBackOff", "false")); got != 0 {
+		t.Errorf("a dry-run action must not be counted as a real one, got %v", got)
+	}
+}
+
+// TestMetrics_PartialFailureIsVisible covers the blind spot the counter exists
+// for: controller-runtime sees a successful reconcile here.
+func TestMetrics_PartialFailureIsVisible(t *testing.T) {
+	resetMetrics()
+
+	policy := newCrashLoopPolicy("failing-policy", withAllReplicasFailing(false))
+	pod := newFailingPod("orphan-pod", testNamespace, rsOwnerRef(), "CrashLoopBackOff", 15)
+	c := &failingOwnerClient{Client: setupTestClient(policy, pod)}
+	r := newReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("failing-policy")); err != nil {
+		t.Fatalf("expected the reconcile to succeed despite the workload error: %v", err)
+	}
+
+	if got := testutil.ToFloat64(policyEvaluationErrors.WithLabelValues("failing-policy")); got == 0 {
+		t.Error("expected the per-workload failure to be counted")
+	}
+	if got := testutil.ToFloat64(policyReady.WithLabelValues("failing-policy")); got != 0 {
+		t.Errorf("expected policy to report not ready, got %v", got)
+	}
+}
+
+// TestMetrics_DeletedPolicyIsForgotten guards the easiest thing to miss:
+// without cleanup the gauges keep reporting on an object that is gone.
+func TestMetrics_DeletedPolicyIsForgotten(t *testing.T) {
+	resetMetrics()
+
+	policy := newCrashLoopPolicy("gone-policy")
+	c := setupTestClient(policy)
+	r := newReconciler(c)
+
+	if _, err := r.Reconcile(testCtx(), testRequest("gone-policy")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := testutil.CollectAndCount(policyReady); got != 1 {
+		t.Fatalf("expected 1 series before deletion, got %d", got)
+	}
+
+	if err := c.Delete(testCtx(), policy); err != nil {
+		t.Fatalf("failed to delete policy: %v", err)
+	}
+	if _, err := r.Reconcile(testCtx(), testRequest("gone-policy")); err != nil {
+		t.Fatalf("unexpected error reconciling a deleted policy: %v", err)
+	}
+
+	if got := testutil.CollectAndCount(policyReady); got != 0 {
+		t.Errorf("expected the ready gauge to be dropped for a deleted policy, got %d series", got)
+	}
+	if got := testutil.CollectAndCount(workloadsScaledDown); got != 0 {
+		t.Errorf("expected the workload gauge to be dropped for a deleted policy, got %d series", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds Prometheus metrics. You asked me to reconsider the set rather than take the April issue at face value, and that was the right call: **two of the four metrics it proposed should not be built.**

- `crashloop_policy_evaluations_total` already exists as `controller_runtime_reconcile_total{controller="crashlooppolicy"}`. controller-runtime registers it for free along with reconcile errors, durations and the workqueue metrics, so building it would produce a second, slightly-wrong copy.
- `crashloop_failing_pods_detected_total` overlaps `kube_pod_container_status_waiting_reason` from kube-state-metrics, which most clusters already run and which is not limited to the reasons one policy happens to watch.

What is left is what only this operator knows:

| Metric | Type | Labels |
|---|---|---|
| `crashloop_scaled_down_total` | Counter | `policy`, `namespace`, `kind`, `reason`, `dry_run` |
| `crashloop_workloads_scaled_down` | Gauge | `policy` |
| `crashloop_policy_evaluation_errors_total` | Counter | `policy` |
| `crashloop_policy_ready` | Gauge | `policy` |

Three things drove the design:

- **The `dry_run` label is the point of the first metric.** While a policy is in dry-run the whole reason you are watching is to see what it *would* do, and without the label a simulated action is indistinguishable from a real one. There is a test asserting exactly that.
- **The error counter covers a real blind spot.** Per-workload failures are counted and surfaced through `Ready`, but deliberately do not fail the reconcile, so `controller_runtime_reconcile_errors_total` sits at zero while a policy quietly fails on every workload it touches. `crashloop_policy_ready` makes that alertable in one expression.
- **No workload name label.** Namespaces are bounded by the cluster; workload names are not, and a series for a workload later deleted would never go away. Workload identity stays in `status.activeScaledDown` and the `scaled-down-by` annotation.

Both gauges are dropped when a policy is deleted. That is the easiest thing to get wrong here, so it has its own test: without it the gauges keep reporting on an object that no longer exists.

The chart side needed nothing new: `metrics.service` and `metrics.serviceMonitor` landed with #26. The README now documents the metrics, the cardinality decision, and two alert rules.

Also aligns `check-tidy` with the other drift gates by diffing against HEAD, so staged changes no longer trip it mid-work.

Closes #6

## Test plan

- Four new tests using `prometheus/client_golang/testutil`, including a full `CollectAndCompare` on the counter with its exact label set, the dry-run distinction, the partial-failure path via the fault-injecting client, and the delete-cleanup case.
- `make ci` passes end to end.
