### PR TITLE
fix(api): drop the enum from a status field

### DIFF
--- a/api/v1alpha1/crashlooppolicy_envtest_test.go
+++ b/api/v1alpha1/crashlooppolicy_envtest_test.go
@@ -309,3 +309,49 @@ func TestSampleManifestsAreValid(t *testing.T) {
 		t.Fatalf("no sample manifests found in %s", dir)
 	}
 }
+
+// TestStatusAcceptsAnyWorkloadKind guards against reintroducing an enum on the
+// status field. The API server validates status writes, so a constrained value
+// there would reject the whole update, not just the offending entry, and every
+// condition and counter would silently stop being written.
+func TestStatusAcceptsAnyWorkloadKind(t *testing.T) {
+	ctx := context.Background()
+	p := newPolicy("status-kind-test")
+	if err := k8sClient.Create(ctx, p); err != nil {
+		t.Fatalf("failed to create policy: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, p) })
+
+	p.Status.Phase = CrashLoopPolicyPhaseActive
+	p.Status.ActiveScaledDown = []ScaledDownWorkloadRef{
+		{Kind: "Deployment", Namespace: "default", Name: "known"},
+		{Kind: "SomeFutureKind", Namespace: "default", Name: "unknown"},
+	}
+	if err := k8sClient.Status().Update(ctx, p); err != nil {
+		t.Fatalf("status write rejected for an unlisted kind: %v", err)
+	}
+
+	fetched := &CrashLoopPolicy{}
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: "status-kind-test"}, fetched); err != nil {
+		t.Fatalf("failed to get policy: %v", err)
+	}
+	// The whole update must have landed, not just the recognised entry.
+	if len(fetched.Status.ActiveScaledDown) != 2 {
+		t.Errorf("expected both entries to persist, got %d", len(fetched.Status.ActiveScaledDown))
+	}
+	if fetched.Status.Phase != CrashLoopPolicyPhaseActive {
+		t.Errorf("expected the rest of the status update to land, phase is %q", fetched.Status.Phase)
+	}
+}
+
+// TestSpecStillRejectsUnknownTarget is the other half: the enum on the spec is
+// the one that should stay, so a user typo is caught at write time.
+func TestSpecStillRejectsUnknownTarget(t *testing.T) {
+	ctx := context.Background()
+	p := newPolicy("spec-target-test")
+	p.Spec.Targets = []string{"SomeFutureKind"}
+	if err := k8sClient.Create(ctx, p); err == nil {
+		t.Error("expected an unknown target kind to be rejected on the spec")
+		_ = k8sClient.Delete(ctx, p)
+	}
+}

--- a/api/v1alpha1/crashlooppolicy_types.go
+++ b/api/v1alpha1/crashlooppolicy_types.go
@@ -74,8 +74,11 @@ type CrashLoopPolicySpec struct {
 // ScaledDownWorkloadRef identifies a workload currently held at zero replicas
 // (or suspended, for CronJobs) by this policy.
 type ScaledDownWorkloadRef struct {
-	// Kind of the workload: Deployment, StatefulSet or CronJob.
-	// +kubebuilder:validation:Enum=Deployment;StatefulSet;CronJob
+	// Kind of the workload, for example Deployment, StatefulSet or CronJob.
+	// Deliberately not constrained by an enum: this is a status field, and the
+	// API server validates status writes, so a value outside the list would
+	// reject the entire status update rather than just this entry. Validate
+	// what users write, describe what the controller reports.
 	Kind string `json:"kind"`
 
 	// Namespace of the workload.

--- a/charts/crashloop-operator/crds/crashloop-operator.lauger.de_crashlooppolicies.yaml
+++ b/charts/crashloop-operator/crds/crashloop-operator.lauger.de_crashlooppolicies.yaml
@@ -237,12 +237,12 @@ spec:
                     (or suspended, for CronJobs) by this policy.
                   properties:
                     kind:
-                      description: 'Kind of the workload: Deployment, StatefulSet
-                        or CronJob.'
-                      enum:
-                      - Deployment
-                      - StatefulSet
-                      - CronJob
+                      description: |-
+                        Kind of the workload, for example Deployment, StatefulSet or CronJob.
+                        Deliberately not constrained by an enum: this is a status field, and the
+                        API server validates status writes, so a value outside the list would
+                        reject the entire status update rather than just this entry. Validate
+                        what users write, describe what the controller reports.
                       type: string
                     name:
                       description: Name of the workload.

--- a/config/crd/bases/crashloop-operator.lauger.de_crashlooppolicies.yaml
+++ b/config/crd/bases/crashloop-operator.lauger.de_crashlooppolicies.yaml
@@ -237,12 +237,12 @@ spec:
                     (or suspended, for CronJobs) by this policy.
                   properties:
                     kind:
-                      description: 'Kind of the workload: Deployment, StatefulSet
-                        or CronJob.'
-                      enum:
-                      - Deployment
-                      - StatefulSet
-                      - CronJob
+                      description: |-
+                        Kind of the workload, for example Deployment, StatefulSet or CronJob.
+                        Deliberately not constrained by an enum: this is a status field, and the
+                        API server validates status writes, so a value outside the list would
+                        reject the entire status update rather than just this entry. Validate
+                        what users write, describe what the controller reports.
                       type: string
                     name:
                       description: Name of the workload.


### PR DESCRIPTION
## Summary

`ScaledDownWorkloadRef.Kind` carried `+kubebuilder:validation:Enum=Deployment;StatefulSet;CronJob`, and that field is part of **status**.

The API server validates status subresource writes. A kind outside the list would therefore have rejected the entire status update, not just that one entry: conditions, phase, the counter and the workload list would all have stopped being written, and the symptom would have looked like an unrelated status bug rather than a validation failure.

Nothing writes an unexpected kind today, so this was latent. It would have become live the moment any work touched the set of supported workload kinds, which is exactly when nobody would be looking for a validation problem.

The same constraint on `spec.targets` is correct and stays. Validate what users write, describe what the controller reports.

Closes #66

## Test plan

Both directions checked against a real API server via envtest:

- The status now accepts an unlisted kind, **and the rest of the update lands with it** — the test asserts the phase and both list entries persist, since a partial write would be its own bug.
- The spec still rejects an unknown target, so the useful validation is intact.
- Verified the guard works by temporarily reinstating the marker: the new test then fails with `status.activeScaledDown[1].kind: Unsupported value`, and the whole write is rejected. That is precisely the behaviour being prevented.
- `make ci` passes.
