### PR TITLE
ci: lint the shell scripts in hack/

### DIFF
--- a/.github/workflows/_shellcheck.yaml
+++ b/.github/workflows/_shellcheck.yaml
@@ -1,0 +1,19 @@
+name: ShellCheck
+
+on:
+  workflow_call:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # hack/ holds the drift and coverage gates. They decide whether CI
+      # passes, so a quoting mistake there fails builds or, worse, makes a
+      # check silently succeed.
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          scandir: hack

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,9 @@ jobs:
   unicode:
     uses: ./.github/workflows/_unicode-lint.yaml
 
+  shellcheck:
+    uses: ./.github/workflows/_shellcheck.yaml
+
   go:
     uses: ./.github/workflows/_go.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,15 @@ check-manifests: manifests generate ## Check for CRD and deepcopy drift.
 		exit 1; \
 	fi
 
+.PHONY: shellcheck
+shellcheck: ## Lint the shell scripts in hack/.
+	@if ! command -v shellcheck >/dev/null 2>&1; then \
+		echo "error: shellcheck not found on PATH."; \
+		echo "Install it from https://github.com/koalaman/shellcheck#installing."; \
+		exit 1; \
+	fi
+	shellcheck hack/*.sh
+
 .PHONY: check-rbac
 check-rbac: manifests ## Check the chart RBAC matches the kubebuilder markers.
 	./hack/check-rbac.sh
@@ -186,7 +195,7 @@ check-helm-docs: helm-docs helm-schema ## Check the chart README and schema are 
 	fi
 
 .PHONY: ci
-ci: lint vet check-tidy check-coverage check-manifests vulncheck helm-lint helm-unittest check-helm-docs check-rbac ## Run all CI checks locally.
+ci: lint vet shellcheck check-tidy check-coverage check-manifests vulncheck helm-lint helm-unittest check-helm-docs check-rbac ## Run all CI checks locally.
 	@echo "All CI checks passed."
 
 ##@ E2E


### PR DESCRIPTION
## Summary

`hack/check-coverage.sh` and `hack/check-rbac.sh` decide whether CI passes, and nothing was linting them. A quoting mistake in a gate either fails builds for the wrong reason or, worse, makes the gate silently succeed while appearing to run.

Both scripts are already clean, so this adds no findings today. The point is the next edit.

Wired into the CI workflow and into `make ci`, so local and CI ask the same question, and `make shellcheck` fails with an install hint rather than doing nothing when the tool is missing.

Scans `hack/` rather than `images/`, since that is where this project's scripts live.

## Test plan

- `shellcheck hack/*.sh` is clean, and `make ci` passes end to end.
- Verified the gate is not inert: appending an unquoted `echo $BROKEN` to one script makes it report SC2086, and removing it restores a clean run.
- `actionlint` reports no findings on the new workflow or the changed `ci.yaml`.
