### PR TITLE
chore: add the Artifact Hub repository ID and badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/slauger/crashloop-operator)](https://goreportcard.com/report/github.com/slauger/crashloop-operator)
 [![Go Reference](https://pkg.go.dev/badge/github.com/slauger/crashloop-operator.svg)](https://pkg.go.dev/github.com/slauger/crashloop-operator)
 [![License](https://img.shields.io/github/license/slauger/crashloop-operator)](LICENSE)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/slauger-crashloop-operator)](https://artifacthub.io/packages/search?repo=slauger-crashloop-operator)
 
 A Kubernetes Operator that watches pods for terminal failure states and scales down (or suspends) the owning workload after configurable thresholds are exceeded. Prevents resource waste and alert fatigue from permanently broken deployments.
 

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,12 +1,13 @@
-# Artifact Hub repository metadata. This file is pushed to the chart's OCI
-# repository during a release so that Artifact Hub can verify who owns it.
+# Artifact Hub repository metadata. The release workflow pushes this file to
+# the chart's OCI repository as an artifacthub.io layer, which is how Artifact
+# Hub verifies who owns the listing and grants the verified-publisher badge.
 #
-# repositoryID is issued by Artifact Hub when the repository is registered as
-# kind OCI with the URL oci://ghcr.io/slauger/charts/crashloop-operator. Until
-# it is filled in the release workflow skips the push, because publishing this
-# file with a blank or wrong ID would fail verification rather than establish
-# it.
-repositoryID: ""
+# The listing is registered as kind Helm with the URL
+# oci://ghcr.io/slauger/charts/crashloop-operator, under the repository name
+# slauger-crashloop-operator because the unprefixed name was already taken.
+# That name only appears in the Artifact Hub URL; the chart itself and the
+# install command are unaffected.
+repositoryID: "b6525baf-0717-4352-9174-bed0afd7efca"
 owners:
   - name: Simon Lauger
     email: simon@lauger.de


### PR DESCRIPTION
## Summary

The Artifact Hub listing is registered, so `repositoryID` is filled in. The release workflow now pushes `artifacthub-repo.yml` as an OCI layer instead of skipping it, which is what earns the verified-publisher badge.

Registered as **`slauger-crashloop-operator`**: the unprefixed name was already taken by an unrelated project whose listing is still live and serving charts, so it was not available. That name appears only in the Artifact Hub URL. The chart name, the OCI path and the install command are all unchanged.

Adds the Artifact Hub badge to the README alongside the existing four, matching the badge row in openvox-operator.

## Test plan

- The workflow's ID extraction returns the UUID rather than an empty string, so the push will no longer be skipped. Both branches of that condition were tested when the step was added.
- The badge endpoint already responds for this slug and reports `slauger-crashloop-operator`, and the search link returns HTTP 200, so the registration is live and the badge will not render broken.
- `make ci` passes.

## Note

The listing has nothing in it until the first release publishes the chart to `oci://ghcr.io/slauger/charts/crashloop-operator`. The badge will show the repository until then.
